### PR TITLE
Generate IDA structures to resolve vtable and structure offsets

### DIFF
--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
@@ -56,6 +56,9 @@ namespace Il2CppInspector
         // Generic method specs for vtables
         public Il2CppMethodSpec[] MethodSpecs { get; private set; }
 
+        // Mapping between GenericInst pointer and index in GenericInstances array
+        public Dictionary<ulong, int> GenericInstanceIndices { get; } = new Dictionary<ulong, int>();
+
         // List of run-time concrete generic class and method signatures
         public List<Il2CppGenericInst> GenericInstances { get; private set; }
 
@@ -243,7 +246,12 @@ namespace Il2CppInspector
             MethodSpecs = image.ReadMappedArray<Il2CppMethodSpec>(MetadataRegistration.methodSpecs, (int) MetadataRegistration.methodSpecsCount);
 
             // Concrete generic class and method signatures
-            GenericInstances = image.ReadMappedObjectPointerArray<Il2CppGenericInst>(MetadataRegistration.genericInsts, (int) MetadataRegistration.genericInstsCount);
+            GenericInstances = new List<Il2CppGenericInst>();
+            var genericInstancePointers = image.ReadMappedArray<ulong>(MetadataRegistration.genericInsts, (int)MetadataRegistration.genericInstsCount);
+            for (int i = 0; i < MetadataRegistration.genericInstsCount; i++) {
+                GenericInstanceIndices.Add(genericInstancePointers[i], i);
+                GenericInstances.Add(image.ReadMappedObject<Il2CppGenericInst>(genericInstancePointers[i]));
+            }
 
             // Concrete generic method pointers
             var genericMethodPointers = image.ReadMappedArray<ulong>(CodeRegistration.genericMethodPointers, (int) CodeRegistration.genericMethodPointersCount);

--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
@@ -53,6 +53,9 @@ namespace Il2CppInspector
         // One invoker specifies a return type and argument list. Multiple methods with the same signature can be invoked with the same invoker
         public ulong[] MethodInvokePointers { get; private set; }
 
+        // Version 16 and below: method references for vtable
+        public uint[] OldMethodReferences { get; private set; }
+
         // Generic method specs for vtables
         public Il2CppMethodSpec[] MethodSpecs { get; private set; }
 
@@ -241,6 +244,10 @@ namespace Il2CppInspector
             // >=21 <=22: ccwMarhsalingFunctions
             // >=22: unresolvedVirtualCallPointers
             // >=23: interopData
+
+            if(Image.Version < 19) {
+                OldMethodReferences = image.ReadMappedArray<uint>(MetadataRegistration.methodReferences, (int)MetadataRegistration.methodReferencesCount);
+            }
 
             // Generic type and method specs (open and closed constructed types)
             MethodSpecs = image.ReadMappedArray<Il2CppMethodSpec>(MetadataRegistration.methodSpecs, (int) MetadataRegistration.methodSpecsCount);

--- a/Il2CppInspector.Common/IL2CPP/Il2CppInspector.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppInspector.cs
@@ -294,6 +294,18 @@ namespace Il2CppInspector
             return Binary.MethodInvokerIndices[module][methodInModule - 1];
         }
 
+        public MetadataUsage[] GetVTable(Il2CppTypeDefinition definition) {
+            MetadataUsage[] res = new MetadataUsage[definition.vtable_count];
+            for (int i = 0; i < definition.vtable_count; i++) {
+                var encodedIndex = VTableMethodIndices[definition.vtableStart + i];
+                var encodedType = encodedIndex & 0xE0000000;
+                var usageType = (MetadataUsageType)(encodedType >> 29);
+                var index = encodedIndex & 0x1FFFFFFF;
+                res[i] = new MetadataUsage(usageType, (int)index, i);
+            }
+            return res;
+        }
+
         public static List<Il2CppInspector> LoadFromFile(string codeFile, string metadataFile) {
             // Load the metadata file
             Metadata metadata;

--- a/Il2CppInspector.Common/IL2CPP/Il2CppInspector.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppInspector.cs
@@ -298,10 +298,17 @@ namespace Il2CppInspector
             MetadataUsage[] res = new MetadataUsage[definition.vtable_count];
             for (int i = 0; i < definition.vtable_count; i++) {
                 var encodedIndex = VTableMethodIndices[definition.vtableStart + i];
-                var encodedType = encodedIndex & 0xE0000000;
-                var usageType = (MetadataUsageType)(encodedType >> 29);
-                var index = encodedIndex & 0x1FFFFFFF;
-                res[i] = new MetadataUsage(usageType, (int)index, i);
+                if (Version < 19) {
+                    var flag = encodedIndex & 0x80000000;
+                    var index = Binary.OldMethodReferences[encodedIndex & 0x7FFFFFFF];
+                    var usageType = (flag != 0) ? MetadataUsageType.MethodRef : MetadataUsageType.MethodDef;
+                    res[i] = new MetadataUsage(usageType, (int)index, i);
+                } else {
+                    var encodedType = encodedIndex & 0xE0000000;
+                    var usageType = (MetadataUsageType)(encodedType >> 29);
+                    var index = encodedIndex & 0x1FFFFFFF;
+                    res[i] = new MetadataUsage(usageType, (int)index, i);
+                }
             }
             return res;
         }

--- a/Il2CppInspector.Common/Il2CppInspector.csproj
+++ b/Il2CppInspector.Common/Il2CppInspector.csproj
@@ -10,6 +10,34 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Outputs\Data\16-5.3.0f4.i" />
+    <None Remove="Outputs\Data\19-5.3.2f1.i" />
+    <None Remove="Outputs\Data\20-5.3.3f1.i" />
+    <None Remove="Outputs\Data\21-5.3.5f1.i" />
+    <None Remove="Outputs\Data\21-5.4.0f3.i" />
+    <None Remove="Outputs\Data\22-5.5.0f3.i" />
+    <None Remove="Outputs\Data\23-5.6.2p3.i" />
+    <None Remove="Outputs\Data\24.0-2017.2f3.i" />
+    <None Remove="Outputs\Data\24.1-2018.3.0f2.i" />
+    <None Remove="Outputs\Data\24.2-2019.2.8f1.i" />
+    <None Remove="Outputs\Data\24.2-2019.3.1f1.i" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Outputs\Data\16-5.3.0f4.i" />
+    <EmbeddedResource Include="Outputs\Data\19-5.3.2f1.i" />
+    <EmbeddedResource Include="Outputs\Data\20-5.3.3f1.i" />
+    <EmbeddedResource Include="Outputs\Data\21-5.3.5f1.i" />
+    <EmbeddedResource Include="Outputs\Data\21-5.4.0f3.i" />
+    <EmbeddedResource Include="Outputs\Data\22-5.5.0f3.i" />
+    <EmbeddedResource Include="Outputs\Data\23-5.6.2p3.i" />
+    <EmbeddedResource Include="Outputs\Data\24.0-2017.2f3.i" />
+    <EmbeddedResource Include="Outputs\Data\24.1-2018.3.0f2.i" />
+    <EmbeddedResource Include="Outputs\Data\24.2-2019.2.8f1.i" />
+    <EmbeddedResource Include="Outputs\Data\24.2-2019.3.1f1.i" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/Il2CppInspector.Common/Outputs/CSharpCodeStubs.cs
+++ b/Il2CppInspector.Common/Outputs/CSharpCodeStubs.cs
@@ -449,7 +449,7 @@ namespace Il2CppInspector.Outputs
                 sb.Append($"{prefix}\t{modifiers}event {evt.EventHandlerType.GetScopedCSharpName(scope)} {evt.CSharpSafeName}");
                 
                 if (!MustCompile) {
-                    sb.Append(" {{\n");
+                    sb.Append(" {\n");
                     var m = new Dictionary<string, (ulong, ulong)?>();
                     if (evt.AddMethod != null) m.Add("add", evt.AddMethod.VirtualAddress);
                     if (evt.RemoveMethod != null) m.Add("remove", evt.RemoveMethod.VirtualAddress);

--- a/Il2CppInspector.Common/Outputs/Data/16-5.3.0f4.i
+++ b/Il2CppInspector.Common/Outputs/Data/16-5.3.0f4.i
@@ -1,0 +1,1337 @@
+typedef void (*methodPointerType)();
+typedef int32_t il2cpp_array_size_t;
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+static inline bool IsGenericMethodIndex (EncodedMethodIndex index)
+{
+ return (index & 0x80000000U) != 0;
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x7FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex delegateWrapperFromManagedToNativeIndex;
+ int32_t marshalingFunctionsIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex delegateWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ Il2CppAssemblyName aname;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct PInvokeArguments
+{
+ const char* moduleName;
+ const char* entryPoint;
+ Il2CppCallConvention callingConvention;
+ Il2CppCharSet charSet;
+ int parameterSize;
+ bool isNoMangle;
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void (*free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+} Il2CppMemoryCallbacks;
+typedef void (*register_object_callback)(void** arr, int size, void* userdata);
+typedef void (*WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+struct Il2CppMetadataField
+{
+ uint32_t offset;
+ uint32_t typeIndex;
+ const char* name;
+ bool isStatic;
+};
+enum Il2CppMetadataTypeFlags
+{
+ kNone = 0,
+ kValueType = 1 << 0,
+ kArray = 1 << 1,
+ kArrayRankMask = 0xFFFF0000
+};
+struct Il2CppMetadataType
+{
+ Il2CppMetadataTypeFlags flags;
+ Il2CppMetadataField* fields;
+ uint32_t fieldCount;
+ uint32_t staticsSize;
+ uint8_t* statics;
+ uint32_t baseOrElementTypeIndex;
+ char* name;
+ const char* assemblyName;
+ uint64_t typeInfoAddress;
+ uint32_t size;
+};
+struct Il2CppMetadataSnapshot
+{
+ uint32_t typeCount;
+ Il2CppMetadataType* types;
+};
+struct Il2CppManagedMemorySection
+{
+ uint64_t sectionStartAddress;
+ uint32_t sectionSize;
+ uint8_t* sectionBytes;
+};
+struct Il2CppManagedHeap
+{
+ uint32_t sectionCount;
+ Il2CppManagedMemorySection* sections;
+};
+struct Il2CppStacks
+{
+ uint32_t stackCount;
+ Il2CppManagedMemorySection* stacks;
+};
+struct NativeObject
+{
+ uint32_t gcHandleIndex;
+ uint32_t size;
+ uint32_t instanceId;
+ uint32_t classId;
+ uint32_t referencedNativeObjectIndicesCount;
+ uint32_t* referencedNativeObjectIndices;
+};
+struct Il2CppGCHandles
+{
+ uint32_t trackedObjectCount;
+ uint64_t* pointersToObjects;
+};
+struct Il2CppRuntimeInformation
+{
+ uint32_t pointerSize;
+ uint32_t objectHeaderSize;
+ uint32_t arrayHeaderSize;
+ uint32_t arrayBoundsOffsetInHeader;
+ uint32_t arraySizeOffsetInHeader;
+ uint32_t allocationGranularity;
+};
+struct Il2CppManagedMemorySnapshot
+{
+ Il2CppManagedHeap heap;
+ Il2CppStacks stacks;
+ Il2CppMetadataSnapshot metadata;
+ Il2CppGCHandles gcHandles;
+ Il2CppRuntimeInformation runtimeInformation;
+ void* additionalUserInformation;
+};
+typedef uint16_t Il2CppChar;
+struct Il2CppClass;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ methodPointerType method;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+#ifdef IS_32BIT
+ uint32_t __padding;
+#endif
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ const MethodInfo** vtable;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+};
+
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppObject* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+};
+struct Il2CppMarshalingFunctions
+{
+ methodPointerType marshal_to_native_func;
+ methodPointerType marshal_from_native_func;
+ methodPointerType marshal_cleanup_func;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const methodPointerType* methodPointers;
+ uint32_t delegateWrappersFromNativeToManagedCount;
+ const methodPointerType** delegateWrappersFromNativeToManaged;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const methodPointerType* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const methodPointerType* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ int32_t methodReferencesCount;
+ const EncodedMethodIndex* methodReferences;
+ FieldIndex fieldOffsetsCount;
+ const int32_t* fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes* typeDefinitionsSizes;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct MonitorData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppDataSegmentString
+{
+ Il2CppObject object;
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ uint16_t chars [32];
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType *parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppObject *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ int32_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef {
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ methodPointerType method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* shortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppWaitHandle {
+ Il2CppMarshalByRefObject object;
+ void* handle;
+ bool disposed;
+};
+struct Il2CppSafeHandle {
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder {
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayed_exc;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acc_socket;
+ int32_t total;
+ bool completed_synch;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};

--- a/Il2CppInspector.Common/Outputs/Data/16-5.3.0f4.i
+++ b/Il2CppInspector.Common/Outputs/Data/16-5.3.0f4.i
@@ -60,7 +60,7 @@ typedef int32_t VTableIndex;
 typedef int32_t InterfaceOffsetIndex;
 typedef int32_t RGCTXIndex;
 typedef int32_t StringIndex;
-typedef int32_t StringLiteralIndex;
+//typedef int32_t StringLiteralIndex; // defined by writeUsages
 typedef int32_t GenericInstIndex;
 typedef int32_t ImageIndex;
 typedef int32_t AssemblyIndex;

--- a/Il2CppInspector.Common/Outputs/Data/19-5.3.2f1.i
+++ b/Il2CppInspector.Common/Outputs/Data/19-5.3.2f1.i
@@ -1,0 +1,1386 @@
+typedef void (*methodPointerType)();
+typedef int32_t il2cpp_array_size_t;
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+ kIl2CppMetadataUsageInvalid,
+ kIl2CppMetadataUsageTypeInfo,
+ kIl2CppMetadataUsageIl2CppType,
+ kIl2CppMetadataUsageMethodDef,
+ kIl2CppMetadataUsageFieldInfo,
+ kIl2CppMetadataUsageStringLiteral,
+ kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType (EncodedMethodIndex index)
+{
+ return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex delegateWrapperFromManagedToNativeIndex;
+ int32_t marshalingFunctionsIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+ uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppFieldRef
+{
+ TypeIndex typeIndex;
+ FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex delegateWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ uint32_t token;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+ uint32_t start;
+ uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+ uint32_t destinationIndex;
+ uint32_t encodedSourceIndex;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+ int32_t metadataUsageListsOffset;
+ int32_t metadataUsageListsCount;
+ int32_t metadataUsagePairsOffset;
+ int32_t metadataUsagePairsCount;
+ int32_t fieldRefsOffset;
+ int32_t fieldRefsCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct PInvokeArguments
+{
+ const char* moduleName;
+ const char* entryPoint;
+ Il2CppCallConvention callingConvention;
+ Il2CppCharSet charSet;
+ int parameterSize;
+ bool isNoMangle;
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void (*free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+} Il2CppMemoryCallbacks;
+typedef void (*register_object_callback)(void** arr, int size, void* userdata);
+typedef void (*WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const char* (*Il2CppSetFindPlugInCallback)(const char*);
+struct Il2CppMetadataField
+{
+ uint32_t offset;
+ uint32_t typeIndex;
+ const char* name;
+ bool isStatic;
+};
+enum Il2CppMetadataTypeFlags
+{
+ kNone = 0,
+ kValueType = 1 << 0,
+ kArray = 1 << 1,
+ kArrayRankMask = 0xFFFF0000
+};
+struct Il2CppMetadataType
+{
+ Il2CppMetadataTypeFlags flags;
+ Il2CppMetadataField* fields;
+ uint32_t fieldCount;
+ uint32_t staticsSize;
+ uint8_t* statics;
+ uint32_t baseOrElementTypeIndex;
+ char* name;
+ const char* assemblyName;
+ uint64_t typeInfoAddress;
+ uint32_t size;
+};
+struct Il2CppMetadataSnapshot
+{
+ uint32_t typeCount;
+ Il2CppMetadataType* types;
+};
+struct Il2CppManagedMemorySection
+{
+ uint64_t sectionStartAddress;
+ uint32_t sectionSize;
+ uint8_t* sectionBytes;
+};
+struct Il2CppManagedHeap
+{
+ uint32_t sectionCount;
+ Il2CppManagedMemorySection* sections;
+};
+struct Il2CppStacks
+{
+ uint32_t stackCount;
+ Il2CppManagedMemorySection* stacks;
+};
+struct NativeObject
+{
+ uint32_t gcHandleIndex;
+ uint32_t size;
+ uint32_t instanceId;
+ uint32_t classId;
+ uint32_t referencedNativeObjectIndicesCount;
+ uint32_t* referencedNativeObjectIndices;
+};
+struct Il2CppGCHandles
+{
+ uint32_t trackedObjectCount;
+ uint64_t* pointersToObjects;
+};
+struct Il2CppRuntimeInformation
+{
+ uint32_t pointerSize;
+ uint32_t objectHeaderSize;
+ uint32_t arrayHeaderSize;
+ uint32_t arrayBoundsOffsetInHeader;
+ uint32_t arraySizeOffsetInHeader;
+ uint32_t allocationGranularity;
+};
+struct Il2CppManagedMemorySnapshot
+{
+ Il2CppManagedHeap heap;
+ Il2CppStacks stacks;
+ Il2CppMetadataSnapshot metadata;
+ Il2CppGCHandles gcHandles;
+ Il2CppRuntimeInformation runtimeInformation;
+ void* additionalUserInformation;
+};
+typedef uint16_t Il2CppChar;
+struct Il2CppClass;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+ int count;
+ Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*, CustomAttributeTypeCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ methodPointerType method;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+#ifdef IS_32BIT
+ uint32_t __padding;
+#endif
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint32_t token;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ const MethodInfo** vtable;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+};
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppObject* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+ uint32_t token;
+};
+struct Il2CppMarshalingFunctions
+{
+ methodPointerType marshal_to_native_func;
+ methodPointerType marshal_from_native_func;
+ methodPointerType marshal_cleanup_func;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const methodPointerType* methodPointers;
+ uint32_t delegateWrappersFromNativeToManagedCount;
+ const methodPointerType** delegateWrappersFromNativeToManaged;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const methodPointerType* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const methodPointerType* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ FieldIndex fieldOffsetsCount;
+ const int32_t* fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes* typeDefinitionsSizes;
+ const size_t metadataUsagesCount;
+ void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct MonitorData;
+
+struct Il2CppReflectionAssembly;
+struct Il2CppObject{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ uint16_t chars [32];
+};
+struct Il2CppDataSegmentString
+{
+ Il2CppObject object;
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType *parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppObject *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ int32_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef {
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ methodPointerType method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* shortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppWaitHandle {
+ Il2CppMarshalByRefObject object;
+ void* handle;
+ bool disposed;
+};
+struct Il2CppSafeHandle {
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder {
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayed_exc;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acc_socket;
+ int32_t total;
+ bool completed_synch;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};

--- a/Il2CppInspector.Common/Outputs/Data/20-5.3.3f1.i
+++ b/Il2CppInspector.Common/Outputs/Data/20-5.3.3f1.i
@@ -1,0 +1,1391 @@
+typedef void (*methodPointerType)();
+typedef int32_t il2cpp_array_size_t;
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+ kIl2CppMetadataUsageInvalid,
+ kIl2CppMetadataUsageTypeInfo,
+ kIl2CppMetadataUsageIl2CppType,
+ kIl2CppMetadataUsageMethodDef,
+ kIl2CppMetadataUsageFieldInfo,
+ kIl2CppMetadataUsageStringLiteral,
+ kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType (EncodedMethodIndex index)
+{
+ return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex delegateWrapperFromManagedToNativeIndex;
+ int32_t marshalingFunctionsIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+ uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppFieldRef
+{
+ TypeIndex typeIndex;
+ FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex delegateWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ uint32_t token;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ int32_t referencedAssemblyStart;
+ int32_t referencedAssemblyCount;
+ Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+ uint32_t start;
+ uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+ uint32_t destinationIndex;
+ uint32_t encodedSourceIndex;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+ int32_t metadataUsageListsOffset;
+ int32_t metadataUsageListsCount;
+ int32_t metadataUsagePairsOffset;
+ int32_t metadataUsagePairsCount;
+ int32_t fieldRefsOffset;
+ int32_t fieldRefsCount;
+ int32_t referencedAssembliesOffset;
+ int32_t referencedAssembliesCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct PInvokeArguments
+{
+ const char* moduleName;
+ const char* entryPoint;
+ Il2CppCallConvention callingConvention;
+ Il2CppCharSet charSet;
+ int parameterSize;
+ bool isNoMangle;
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void* (*aligned_malloc_func)(size_t size, size_t alignment);
+ void (*free_func)(void *ptr);
+ void (*aligned_free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+ void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef void (*register_object_callback)(void** arr, int size, void* userdata);
+typedef void (*WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const char* (*Il2CppSetFindPlugInCallback)(const char*);
+struct Il2CppMetadataField
+{
+ uint32_t offset;
+ uint32_t typeIndex;
+ const char* name;
+ bool isStatic;
+};
+enum Il2CppMetadataTypeFlags
+{
+ kNone = 0,
+ kValueType = 1 << 0,
+ kArray = 1 << 1,
+ kArrayRankMask = 0xFFFF0000
+};
+struct Il2CppMetadataType
+{
+ Il2CppMetadataTypeFlags flags;
+ Il2CppMetadataField* fields;
+ uint32_t fieldCount;
+ uint32_t staticsSize;
+ uint8_t* statics;
+ uint32_t baseOrElementTypeIndex;
+ char* name;
+ const char* assemblyName;
+ uint64_t typeInfoAddress;
+ uint32_t size;
+};
+struct Il2CppMetadataSnapshot
+{
+ uint32_t typeCount;
+ Il2CppMetadataType* types;
+};
+struct Il2CppManagedMemorySection
+{
+ uint64_t sectionStartAddress;
+ uint32_t sectionSize;
+ uint8_t* sectionBytes;
+};
+struct Il2CppManagedHeap
+{
+ uint32_t sectionCount;
+ Il2CppManagedMemorySection* sections;
+};
+struct Il2CppStacks
+{
+ uint32_t stackCount;
+ Il2CppManagedMemorySection* stacks;
+};
+struct NativeObject
+{
+ uint32_t gcHandleIndex;
+ uint32_t size;
+ uint32_t instanceId;
+ uint32_t classId;
+ uint32_t referencedNativeObjectIndicesCount;
+ uint32_t* referencedNativeObjectIndices;
+};
+struct Il2CppGCHandles
+{
+ uint32_t trackedObjectCount;
+ uint64_t* pointersToObjects;
+};
+struct Il2CppRuntimeInformation
+{
+ uint32_t pointerSize;
+ uint32_t objectHeaderSize;
+ uint32_t arrayHeaderSize;
+ uint32_t arrayBoundsOffsetInHeader;
+ uint32_t arraySizeOffsetInHeader;
+ uint32_t allocationGranularity;
+};
+struct Il2CppManagedMemorySnapshot
+{
+ Il2CppManagedHeap heap;
+ Il2CppStacks stacks;
+ Il2CppMetadataSnapshot metadata;
+ Il2CppGCHandles gcHandles;
+ Il2CppRuntimeInformation runtimeInformation;
+ void* additionalUserInformation;
+};
+typedef uint16_t Il2CppChar;
+struct Il2CppClass;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+ int count;
+ Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*, CustomAttributeTypeCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ methodPointerType method;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+#ifdef IS_32BIT
+ uint32_t __padding;
+#endif
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint32_t token;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+ uint8_t is_import : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ const MethodInfo** vtable;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+};
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppObject* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+ uint32_t token;
+};
+struct Il2CppMarshalingFunctions
+{
+ methodPointerType marshal_to_native_func;
+ methodPointerType marshal_from_native_func;
+ methodPointerType marshal_cleanup_func;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const methodPointerType* methodPointers;
+ uint32_t delegateWrappersFromNativeToManagedCount;
+ const methodPointerType** delegateWrappersFromNativeToManaged;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const methodPointerType* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const methodPointerType* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ FieldIndex fieldOffsetsCount;
+ const int32_t* fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes* typeDefinitionsSizes;
+ const size_t metadataUsagesCount;
+ void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct MonitorData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ uint16_t chars [32];
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType *parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppObject *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ il2cpp_hresult_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ methodPointerType method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* shortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppWaitHandle {
+ Il2CppMarshalByRefObject object;
+ void* handle;
+ bool disposed;
+};
+struct Il2CppSafeHandle {
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder {
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayed_exc;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acc_socket;
+ int32_t total;
+ bool completed_synch;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};

--- a/Il2CppInspector.Common/Outputs/Data/21-5.3.5f1.i
+++ b/Il2CppInspector.Common/Outputs/Data/21-5.3.5f1.i
@@ -1,0 +1,1349 @@
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t GuidIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const GuidIndex kGuidIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+ kIl2CppMetadataUsageInvalid,
+ kIl2CppMetadataUsageTypeInfo,
+ kIl2CppMetadataUsageIl2CppType,
+ kIl2CppMetadataUsageMethodDef,
+ kIl2CppMetadataUsageFieldInfo,
+ kIl2CppMetadataUsageStringLiteral,
+ kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType (EncodedMethodIndex index)
+{
+ return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex delegateWrapperFromManagedToNativeIndex;
+ int32_t marshalingFunctionsIndex;
+ int32_t ccwFunctionIndex;
+ GuidIndex guidIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+ uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppFieldRef
+{
+ TypeIndex typeIndex;
+ FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex delegateWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ uint32_t token;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ int32_t referencedAssemblyStart;
+ int32_t referencedAssemblyCount;
+ Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+ uint32_t start;
+ uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+ uint32_t destinationIndex;
+ uint32_t encodedSourceIndex;
+};
+struct Il2CppCustomAttributeTypeRange
+{
+ int32_t start;
+ int32_t count;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+ int32_t metadataUsageListsOffset;
+ int32_t metadataUsageListsCount;
+ int32_t metadataUsagePairsOffset;
+ int32_t metadataUsagePairsCount;
+ int32_t fieldRefsOffset;
+ int32_t fieldRefsCount;
+ int32_t referencedAssembliesOffset;
+ int32_t referencedAssembliesCount;
+ int32_t attributesInfoOffset;
+ int32_t attributesInfoCount;
+ int32_t attributeTypesOffset;
+ int32_t attributeTypesCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct PInvokeArguments
+{
+ const char* moduleName;
+ const char* entryPoint;
+ Il2CppCallConvention callingConvention;
+ Il2CppCharSet charSet;
+ int parameterSize;
+ bool isNoMangle;
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void* (*aligned_malloc_func)(size_t size, size_t alignment);
+ void (*free_func)(void *ptr);
+ void (*aligned_free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+ void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const char* (*Il2CppSetFindPlugInCallback)(const char*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef int32_t il2cpp_array_size_t;
+typedef uint16_t Il2CppChar;
+struct Il2CppClass;
+struct Il2CppGuid;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *il2cpp_com_object_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+ Il2CppClass *dbnull_class;
+ Il2CppClass *error_wrapper_class;
+ Il2CppClass *missing_class;
+ Il2CppClass *value_type_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+ int count;
+ Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ Il2CppMethodPointer method;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+#ifdef IS_32BIT
+ uint32_t __padding;
+#endif
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint32_t token;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+ uint8_t is_import : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ const MethodInfo** vtable;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+};
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppObject* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+ uint32_t token;
+};
+struct Il2CppMarshalingFunctions
+{
+ Il2CppMethodPointer marshal_to_native_func;
+ Il2CppMethodPointer marshal_from_native_func;
+ Il2CppMethodPointer marshal_cleanup_func;
+};
+struct Il2CppCodeGenOptions
+{
+ bool enablePrimitiveValueTypeGenericSharing;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const Il2CppMethodPointer* methodPointers;
+ uint32_t delegateWrappersFromNativeToManagedCount;
+ const Il2CppMethodPointer** delegateWrappersFromNativeToManaged;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const Il2CppMethodPointer* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t ccwMarshalingFunctionsCount;
+ const Il2CppMethodPointer* ccwMarshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const Il2CppMethodPointer* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+ GuidIndex guidCount;
+ const Il2CppGuid** guids;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ FieldIndex fieldOffsetsCount;
+ const int32_t* fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes* typeDefinitionsSizes;
+ const size_t metadataUsagesCount;
+ void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct Il2CppIUnknown;
+struct MonitorData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ uint16_t chars [32];
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType *parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppException *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ il2cpp_hresult_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ Il2CppMethodPointer method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppComObject {
+ Il2CppObject obj;
+ Il2CppIUnknown *identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* shortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppWaitHandle {
+ Il2CppMarshalByRefObject object;
+ void* handle;
+ bool disposed;
+};
+struct Il2CppSafeHandle {
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder {
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppErrorWrapper
+{
+ Il2CppObject base;
+ int32_t errorCode;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayed_exc;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acc_socket;
+ int32_t total;
+ bool completed_synch;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};

--- a/Il2CppInspector.Common/Outputs/Data/21-5.4.0f3.i
+++ b/Il2CppInspector.Common/Outputs/Data/21-5.4.0f3.i
@@ -1,0 +1,1411 @@
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t GuidIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const GuidIndex kGuidIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+ kIl2CppMetadataUsageInvalid,
+ kIl2CppMetadataUsageTypeInfo,
+ kIl2CppMetadataUsageIl2CppType,
+ kIl2CppMetadataUsageMethodDef,
+ kIl2CppMetadataUsageFieldInfo,
+ kIl2CppMetadataUsageStringLiteral,
+ kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType (EncodedMethodIndex index)
+{
+ return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex reversePInvokeWrapperIndex;
+ int32_t marshalingFunctionsIndex;
+ int32_t ccwFunctionIndex;
+ GuidIndex guidIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+ uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppFieldRef
+{
+ TypeIndex typeIndex;
+ FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex reversePInvokeWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ uint32_t token;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ int32_t referencedAssemblyStart;
+ int32_t referencedAssemblyCount;
+ Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+ uint32_t start;
+ uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+ uint32_t destinationIndex;
+ uint32_t encodedSourceIndex;
+};
+struct Il2CppCustomAttributeTypeRange
+{
+ int32_t start;
+ int32_t count;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+ int32_t metadataUsageListsOffset;
+ int32_t metadataUsageListsCount;
+ int32_t metadataUsagePairsOffset;
+ int32_t metadataUsagePairsCount;
+ int32_t fieldRefsOffset;
+ int32_t fieldRefsCount;
+ int32_t referencedAssembliesOffset;
+ int32_t referencedAssembliesCount;
+ int32_t attributesInfoOffset;
+ int32_t attributesInfoCount;
+ int32_t attributeTypesOffset;
+ int32_t attributeTypesCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void* (*aligned_malloc_func)(size_t size, size_t alignment);
+ void (*free_func)(void *ptr);
+ void (*aligned_free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+ void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef int32_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct Il2CppGuid;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+struct VirtualInvokeData;
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *il2cpp_com_object_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+ Il2CppClass *dbnull_class;
+ Il2CppClass *error_wrapper_class;
+ Il2CppClass *missing_class;
+ Il2CppClass *value_type_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+ int count;
+ Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ Il2CppMethodPointer methodPointer;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+#ifdef IS_32BIT
+ uint32_t __padding;
+#endif
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint32_t token;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+ uint8_t is_import_or_windows_runtime : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ VirtualInvokeData* vtable;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+};
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppObject* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+ uint32_t token;
+};
+struct Il2CppMarshalingFunctions
+{
+ Il2CppMethodPointer marshal_to_native_func;
+ Il2CppMethodPointer marshal_from_native_func;
+ Il2CppMethodPointer marshal_cleanup_func;
+};
+struct Il2CppCodeGenOptions
+{
+ bool enablePrimitiveValueTypeGenericSharing;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const Il2CppMethodPointer* methodPointers;
+ uint32_t reversePInvokeWrapperCount;
+ const Il2CppMethodPointer* reversePInvokeWrappers;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const Il2CppMethodPointer* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t ccwMarshalingFunctionsCount;
+ const Il2CppMethodPointer* ccwMarshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const Il2CppMethodPointer* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+ GuidIndex guidCount;
+ const Il2CppGuid** guids;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ FieldIndex fieldOffsetsCount;
+ const int32_t* fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes* typeDefinitionsSizes;
+ const size_t metadataUsagesCount;
+ void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppPerfCounters
+{
+ uint32_t jit_methods;
+ uint32_t jit_bytes;
+ uint32_t jit_time;
+ uint32_t jit_failures;
+ uint32_t exceptions_thrown;
+ uint32_t exceptions_filters;
+ uint32_t exceptions_finallys;
+ uint32_t exceptions_depth;
+ uint32_t aspnet_requests_queued;
+ uint32_t aspnet_requests;
+ uint32_t gc_collections0;
+ uint32_t gc_collections1;
+ uint32_t gc_collections2;
+ uint32_t gc_promotions0;
+ uint32_t gc_promotions1;
+ uint32_t gc_promotion_finalizers;
+ uint32_t gc_gen0size;
+ uint32_t gc_gen1size;
+ uint32_t gc_gen2size;
+ uint32_t gc_lossize;
+ uint32_t gc_fin_survivors;
+ uint32_t gc_num_handles;
+ uint32_t gc_allocated;
+ uint32_t gc_induced;
+ uint32_t gc_time;
+ uint32_t gc_total_bytes;
+ uint32_t gc_committed_bytes;
+ uint32_t gc_reserved_bytes;
+ uint32_t gc_num_pinned;
+ uint32_t gc_sync_blocks;
+ uint32_t remoting_calls;
+ uint32_t remoting_channels;
+ uint32_t remoting_proxies;
+ uint32_t remoting_classes;
+ uint32_t remoting_objects;
+ uint32_t remoting_contexts;
+ uint32_t loader_classes;
+ uint32_t loader_total_classes;
+ uint32_t loader_appdomains;
+ uint32_t loader_total_appdomains;
+ uint32_t loader_assemblies;
+ uint32_t loader_total_assemblies;
+ uint32_t loader_failures;
+ uint32_t loader_bytes;
+ uint32_t loader_appdomains_uloaded;
+ uint32_t thread_contentions;
+ uint32_t thread_queue_len;
+ uint32_t thread_queue_max;
+ uint32_t thread_num_logical;
+ uint32_t thread_num_physical;
+ uint32_t thread_cur_recognized;
+ uint32_t thread_num_recognized;
+ uint32_t interop_num_ccw;
+ uint32_t interop_num_stubs;
+ uint32_t interop_num_marshals;
+ uint32_t security_num_checks;
+ uint32_t security_num_link_checks;
+ uint32_t security_time;
+ uint32_t security_depth;
+ uint32_t unused;
+ uint64_t threadpool_workitems;
+ uint64_t threadpool_ioworkitems;
+ unsigned int threadpool_threads;
+ unsigned int threadpool_iothreads;
+};
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct Il2CppIUnknown;
+struct MonitorData;
+struct VirtualInvokeData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ Il2CppChar chars [32];
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType *parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppException *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ il2cpp_hresult_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ Il2CppMethodPointer method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppComObject
+{
+ Il2CppObject obj;
+ Il2CppIUnknown* identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* shortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppWaitHandle {
+ Il2CppMarshalByRefObject object;
+ void* handle;
+ bool disposed;
+};
+struct Il2CppSafeHandle {
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder {
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppErrorWrapper
+{
+ Il2CppObject base;
+ int32_t errorCode;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayed_exc;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acc_socket;
+ int32_t total;
+ bool completed_synch;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};

--- a/Il2CppInspector.Common/Outputs/Data/22-5.5.0f3.i
+++ b/Il2CppInspector.Common/Outputs/Data/22-5.5.0f3.i
@@ -1,0 +1,1463 @@
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+enum Il2CppTypeEnum {
+ IL2CPP_TYPE_END = 0x00,
+ IL2CPP_TYPE_VOID = 0x01,
+ IL2CPP_TYPE_BOOLEAN = 0x02,
+ IL2CPP_TYPE_CHAR = 0x03,
+ IL2CPP_TYPE_I1 = 0x04,
+ IL2CPP_TYPE_U1 = 0x05,
+ IL2CPP_TYPE_I2 = 0x06,
+ IL2CPP_TYPE_U2 = 0x07,
+ IL2CPP_TYPE_I4 = 0x08,
+ IL2CPP_TYPE_U4 = 0x09,
+ IL2CPP_TYPE_I8 = 0x0a,
+ IL2CPP_TYPE_U8 = 0x0b,
+ IL2CPP_TYPE_R4 = 0x0c,
+ IL2CPP_TYPE_R8 = 0x0d,
+ IL2CPP_TYPE_STRING = 0x0e,
+ IL2CPP_TYPE_PTR = 0x0f,
+ IL2CPP_TYPE_BYREF = 0x10,
+ IL2CPP_TYPE_VALUETYPE = 0x11,
+ IL2CPP_TYPE_CLASS = 0x12,
+ IL2CPP_TYPE_VAR = 0x13,
+ IL2CPP_TYPE_ARRAY = 0x14,
+ IL2CPP_TYPE_GENERICINST= 0x15,
+ IL2CPP_TYPE_TYPEDBYREF = 0x16,
+ IL2CPP_TYPE_I = 0x18,
+ IL2CPP_TYPE_U = 0x19,
+ IL2CPP_TYPE_FNPTR = 0x1b,
+ IL2CPP_TYPE_OBJECT = 0x1c,
+ IL2CPP_TYPE_SZARRAY = 0x1d,
+ IL2CPP_TYPE_MVAR = 0x1e,
+ IL2CPP_TYPE_CMOD_REQD = 0x1f,
+ IL2CPP_TYPE_CMOD_OPT = 0x20,
+ IL2CPP_TYPE_INTERNAL = 0x21,
+ IL2CPP_TYPE_MODIFIER = 0x40,
+ IL2CPP_TYPE_SENTINEL = 0x41,
+ IL2CPP_TYPE_PINNED = 0x45,
+ IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t GuidIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const GuidIndex kGuidIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+ kIl2CppMetadataUsageInvalid,
+ kIl2CppMetadataUsageTypeInfo,
+ kIl2CppMetadataUsageIl2CppType,
+ kIl2CppMetadataUsageMethodDef,
+ kIl2CppMetadataUsageFieldInfo,
+ kIl2CppMetadataUsageStringLiteral,
+ kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType (EncodedMethodIndex index)
+{
+ return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex (EncodedMethodIndex index)
+{
+ return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+ int32_t rgctxDataDummy;
+ MethodIndex methodIndex;
+ TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+ IL2CPP_RGCTX_DATA_INVALID,
+ IL2CPP_RGCTX_DATA_TYPE,
+ IL2CPP_RGCTX_DATA_CLASS,
+ IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+ Il2CppRGCTXDataType type;
+ Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+ TypeIndex interfaceTypeIndex;
+ int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+ StringIndex nameIndex;
+ StringIndex namespaceIndex;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex byvalTypeIndex;
+ TypeIndex byrefTypeIndex;
+ TypeIndex declaringTypeIndex;
+ TypeIndex parentIndex;
+ TypeIndex elementTypeIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex reversePInvokeWrapperIndex;
+ int32_t marshalingFunctionsIndex;
+ int32_t ccwFunctionIndex;
+ GuidIndex guidIndex;
+ uint32_t flags;
+ FieldIndex fieldStart;
+ MethodIndex methodStart;
+ EventIndex eventStart;
+ PropertyIndex propertyStart;
+ NestedTypeIndex nestedTypesStart;
+ InterfacesIndex interfacesStart;
+ VTableIndex vtableStart;
+ InterfacesIndex interfaceOffsetsStart;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint32_t bitfield;
+ uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+ FieldIndex fieldIndex;
+ TypeIndex typeIndex;
+ int32_t size;
+};
+struct Il2CppFieldRef
+{
+ TypeIndex typeIndex;
+ FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+ StringIndex nameIndex;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+ ParameterIndex parameterIndex;
+ TypeIndex typeIndex;
+ DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+ StringIndex nameIndex;
+ TypeDefinitionIndex declaringType;
+ TypeIndex returnType;
+ ParameterIndex parameterStart;
+ CustomAttributeIndex customAttributeIndex;
+ GenericContainerIndex genericContainerIndex;
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+ MethodIndex reversePInvokeWrapperIndex;
+ RGCTXIndex rgctxStartIndex;
+ int32_t rgctxCount;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+ StringIndex nameIndex;
+ TypeIndex typeIndex;
+ MethodIndex add;
+ MethodIndex remove;
+ MethodIndex raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+ StringIndex nameIndex;
+ MethodIndex get;
+ MethodIndex set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+ MethodIndex methodDefinitionIndex;
+ GenericInstIndex classIndexIndex;
+ GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+ uint32_t length;
+ StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+ MethodIndex methodIndex;
+ MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+ GenericMethodIndex genericMethodIndex;
+ Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+ StringIndex nameIndex;
+ StringIndex cultureIndex;
+ StringIndex hashValueIndex;
+ StringIndex publicKeyIndex;
+ uint32_t hash_alg;
+ int32_t hash_len;
+ uint32_t flags;
+ int32_t major;
+ int32_t minor;
+ int32_t build;
+ int32_t revision;
+ uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+ StringIndex nameIndex;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ uint32_t token;
+};
+struct Il2CppAssembly
+{
+ ImageIndex imageIndex;
+ CustomAttributeIndex customAttributeIndex;
+ int32_t referencedAssemblyStart;
+ int32_t referencedAssemblyCount;
+ Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+ uint32_t start;
+ uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+ uint32_t destinationIndex;
+ uint32_t encodedSourceIndex;
+};
+struct Il2CppCustomAttributeTypeRange
+{
+ int32_t start;
+ int32_t count;
+};
+struct Il2CppRange
+{
+ int32_t start;
+ int32_t length;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+ int32_t sanity;
+ int32_t version;
+ int32_t stringLiteralOffset;
+ int32_t stringLiteralCount;
+ int32_t stringLiteralDataOffset;
+ int32_t stringLiteralDataCount;
+ int32_t stringOffset;
+ int32_t stringCount;
+ int32_t eventsOffset;
+ int32_t eventsCount;
+ int32_t propertiesOffset;
+ int32_t propertiesCount;
+ int32_t methodsOffset;
+ int32_t methodsCount;
+ int32_t parameterDefaultValuesOffset;
+ int32_t parameterDefaultValuesCount;
+ int32_t fieldDefaultValuesOffset;
+ int32_t fieldDefaultValuesCount;
+ int32_t fieldAndParameterDefaultValueDataOffset;
+ int32_t fieldAndParameterDefaultValueDataCount;
+ int32_t fieldMarshaledSizesOffset;
+ int32_t fieldMarshaledSizesCount;
+ int32_t parametersOffset;
+ int32_t parametersCount;
+ int32_t fieldsOffset;
+ int32_t fieldsCount;
+ int32_t genericParametersOffset;
+ int32_t genericParametersCount;
+ int32_t genericParameterConstraintsOffset;
+ int32_t genericParameterConstraintsCount;
+ int32_t genericContainersOffset;
+ int32_t genericContainersCount;
+ int32_t nestedTypesOffset;
+ int32_t nestedTypesCount;
+ int32_t interfacesOffset;
+ int32_t interfacesCount;
+ int32_t vtableMethodsOffset;
+ int32_t vtableMethodsCount;
+ int32_t interfaceOffsetsOffset;
+ int32_t interfaceOffsetsCount;
+ int32_t typeDefinitionsOffset;
+ int32_t typeDefinitionsCount;
+ int32_t rgctxEntriesOffset;
+ int32_t rgctxEntriesCount;
+ int32_t imagesOffset;
+ int32_t imagesCount;
+ int32_t assembliesOffset;
+ int32_t assembliesCount;
+ int32_t metadataUsageListsOffset;
+ int32_t metadataUsageListsCount;
+ int32_t metadataUsagePairsOffset;
+ int32_t metadataUsagePairsCount;
+ int32_t fieldRefsOffset;
+ int32_t fieldRefsCount;
+ int32_t referencedAssembliesOffset;
+ int32_t referencedAssembliesCount;
+ int32_t attributesInfoOffset;
+ int32_t attributesInfoCount;
+ int32_t attributeTypesOffset;
+ int32_t attributeTypesCount;
+ int32_t unresolvedVirtualCallParameterTypesOffset;
+ int32_t unresolvedVirtualCallParameterTypesCount;
+ int32_t unresolvedVirtualCallParameterRangesOffset;
+ int32_t unresolvedVirtualCallParameterRangesCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType {
+ const Il2CppType* etype;
+ uint8_t rank;
+ uint8_t numsizes;
+ uint8_t numlobounds;
+ int *sizes;
+ int *lobounds;
+};
+struct Il2CppGenericInst {
+ uint32_t type_argc;
+ const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext {
+ const Il2CppGenericInst *class_inst;
+ const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+ GenericContainerIndex ownerIndex;
+ StringIndex nameIndex;
+ GenericParameterConstraintIndex constraintsStart;
+ int16_t constraintsCount;
+ uint16_t num;
+ uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+ int32_t ownerIndex;
+ int32_t type_argc;
+ int32_t is_method;
+ GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+ TypeDefinitionIndex typeDefinitionIndex;
+ Il2CppGenericContext context;
+ Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+ const MethodInfo* methodDefinition;
+ Il2CppGenericContext context;
+};
+struct Il2CppType {
+ union {
+  void* dummy;
+  TypeDefinitionIndex klassIndex;
+  const Il2CppType *type;
+  Il2CppArrayType *array;
+  GenericParameterIndex genericParameterIndex;
+  Il2CppGenericClass *generic_class;
+ } data;
+ unsigned int attrs : 16;
+ Il2CppTypeEnum type : 8;
+ unsigned int num_mods : 6;
+ unsigned int byref : 1;
+ unsigned int pinned : 1;
+};
+typedef enum {
+ IL2CPP_CALL_DEFAULT,
+ IL2CPP_CALL_C,
+ IL2CPP_CALL_STDCALL,
+ IL2CPP_CALL_THISCALL,
+ IL2CPP_CALL_FASTCALL,
+ IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+ CHARSET_ANSI,
+ CHARSET_UNICODE
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags {
+ IL2CPP_PROFILE_NONE = 0,
+ IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+ IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+ IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+ IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+ IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+ IL2CPP_PROFILE_INLINING = 1 << 5,
+ IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+ IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+ IL2CPP_PROFILE_GC = 1 << 8,
+ IL2CPP_PROFILE_THREADS = 1 << 9,
+ IL2CPP_PROFILE_REMOTING = 1 << 10,
+ IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+ IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+ IL2CPP_PROFILE_COVERAGE = 1 << 13,
+ IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+ IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+ IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+ IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+ IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+ IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent {
+ IL2CPP_GC_EVENT_START,
+ IL2CPP_GC_EVENT_MARK_START,
+ IL2CPP_GC_EVENT_MARK_END,
+ IL2CPP_GC_EVENT_RECLAIM_START,
+ IL2CPP_GC_EVENT_RECLAIM_END,
+ IL2CPP_GC_EVENT_END,
+ IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+ IL2CPP_GC_EVENT_POST_STOP_WORLD,
+ IL2CPP_GC_EVENT_PRE_START_WORLD,
+ IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat {
+ IL2CPP_STAT_NEW_OBJECT_COUNT,
+ IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+ IL2CPP_STAT_METHOD_COUNT,
+ IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+ IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+ IL2CPP_STAT_GENERIC_CLASS_COUNT,
+ IL2CPP_STAT_INFLATED_METHOD_COUNT,
+ IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+ FRAME_TYPE_MANAGED = 0,
+ FRAME_TYPE_DEBUGGER_INVOKE = 1,
+ FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+ FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy {
+ IL2CPP_UNHANDLED_POLICY_LEGACY,
+ IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+ const MethodInfo *method;
+};
+typedef struct {
+ void* (*malloc_func)(size_t size);
+ void* (*aligned_malloc_func)(size_t size, size_t alignment);
+ void (*free_func)(void *ptr);
+ void (*aligned_free_func)(void *ptr);
+ void* (*calloc_func)(size_t nmemb, size_t size);
+ void* (*realloc_func)(void *ptr, size_t size);
+ void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef uint16_t Il2CppChar;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef int32_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct Il2CppGuid;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppAppDomainSetup;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+struct VirtualInvokeData
+{
+ Il2CppMethodPointer methodPtr;
+ const MethodInfo* method;
+};
+enum Il2CppTypeNameFormat {
+ IL2CPP_TYPE_NAME_FORMAT_IL,
+ IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+ IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+ IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct {
+ Il2CppImage *corlib;
+ Il2CppClass *object_class;
+ Il2CppClass *byte_class;
+ Il2CppClass *void_class;
+ Il2CppClass *boolean_class;
+ Il2CppClass *sbyte_class;
+ Il2CppClass *int16_class;
+ Il2CppClass *uint16_class;
+ Il2CppClass *int32_class;
+ Il2CppClass *uint32_class;
+ Il2CppClass *int_class;
+ Il2CppClass *uint_class;
+ Il2CppClass *int64_class;
+ Il2CppClass *uint64_class;
+ Il2CppClass *single_class;
+ Il2CppClass *double_class;
+ Il2CppClass *char_class;
+ Il2CppClass *string_class;
+ Il2CppClass *enum_class;
+ Il2CppClass *array_class;
+ Il2CppClass *delegate_class;
+ Il2CppClass *multicastdelegate_class;
+ Il2CppClass *asyncresult_class;
+ Il2CppClass *manualresetevent_class;
+ Il2CppClass *typehandle_class;
+ Il2CppClass *fieldhandle_class;
+ Il2CppClass *methodhandle_class;
+ Il2CppClass *systemtype_class;
+ Il2CppClass *monotype_class;
+ Il2CppClass *exception_class;
+ Il2CppClass *threadabortexception_class;
+ Il2CppClass *thread_class;
+ Il2CppClass *appdomain_class;
+ Il2CppClass *appdomain_setup_class;
+ Il2CppClass *field_info_class;
+ Il2CppClass *method_info_class;
+ Il2CppClass *property_info_class;
+ Il2CppClass *event_info_class;
+ Il2CppClass *mono_event_info_class;
+ Il2CppClass *stringbuilder_class;
+ Il2CppClass *stack_frame_class;
+ Il2CppClass *stack_trace_class;
+ Il2CppClass *marshal_class;
+ Il2CppClass *typed_reference_class;
+ Il2CppClass *marshalbyrefobject_class;
+ Il2CppClass *generic_ilist_class;
+ Il2CppClass *generic_icollection_class;
+ Il2CppClass *generic_ienumerable_class;
+ Il2CppClass *generic_nullable_class;
+ Il2CppClass *il2cpp_com_object_class;
+ Il2CppClass *customattribute_data_class;
+ Il2CppClass *version;
+ Il2CppClass *culture_info;
+ Il2CppClass *async_call_class;
+ Il2CppClass *assembly_class;
+ Il2CppClass *assembly_name_class;
+ Il2CppClass *enum_info_class;
+ Il2CppClass *mono_field_class;
+ Il2CppClass *mono_method_class;
+ Il2CppClass *mono_method_info_class;
+ Il2CppClass *mono_property_info_class;
+ Il2CppClass *parameter_info_class;
+ Il2CppClass *module_class;
+ Il2CppClass *pointer_class;
+ Il2CppClass *system_exception_class;
+ Il2CppClass *argument_exception_class;
+ Il2CppClass *wait_handle_class;
+ Il2CppClass *safe_handle_class;
+ Il2CppClass *sort_key_class;
+ Il2CppClass *dbnull_class;
+ Il2CppClass *error_wrapper_class;
+ Il2CppClass *missing_class;
+ Il2CppClass *value_type_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+ int count;
+ Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+ int count;
+ Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+ const char* name;
+ const Il2CppType* type;
+ Il2CppClass *parent;
+ int32_t offset;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct PropertyInfo
+{
+ Il2CppClass *parent;
+ const char *name;
+ const MethodInfo *get;
+ const MethodInfo *set;
+ uint32_t attrs;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct EventInfo
+{
+ const char* name;
+ const Il2CppType* eventType;
+ Il2CppClass* parent;
+ const MethodInfo* add;
+ const MethodInfo* remove;
+ const MethodInfo* raise;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+};
+struct ParameterInfo
+{
+ const char* name;
+ int32_t position;
+ uint32_t token;
+ CustomAttributeIndex customAttributeIndex;
+ const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+ void* rgctxDataDummy;
+ const MethodInfo* method;
+ const Il2CppType* type;
+ Il2CppClass* klass;
+};
+struct MethodInfo
+{
+ Il2CppMethodPointer methodPointer;
+ InvokerMethod invoker_method;
+ const char* name;
+ Il2CppClass *declaring_type;
+ const Il2CppType *return_type;
+ const ParameterInfo* parameters;
+ union
+ {
+  const Il2CppRGCTXData* rgctx_data;
+  const Il2CppMethodDefinition* methodDefinition;
+ };
+ union
+ {
+  const Il2CppGenericMethod* genericMethod;
+  const Il2CppGenericContainer* genericContainer;
+ };
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t token;
+ uint16_t flags;
+ uint16_t iflags;
+ uint16_t slot;
+ uint8_t parameters_count;
+ uint8_t is_generic : 1;
+ uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+ Il2CppClass* interfaceType;
+ int32_t offset;
+};
+struct Il2CppClass_0
+{
+ const Il2CppImage* image;
+ void* gc_desc;
+ const char* name;
+ const char* namespaze;
+ const Il2CppType* byval_arg;
+ const Il2CppType* this_arg;
+ Il2CppClass* element_class;
+ Il2CppClass* castClass;
+ Il2CppClass* declaringType;
+ Il2CppClass* parent;
+ Il2CppGenericClass *generic_class;
+ const Il2CppTypeDefinition* typeDefinition;
+ FieldInfo* fields;
+ const EventInfo* events;
+ const PropertyInfo* properties;
+ const MethodInfo** methods;
+ Il2CppClass** nestedTypes;
+ Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+ Il2CppClass** typeHierarchy;
+ uint32_t cctor_started;
+ uint32_t cctor_finished;
+ uint64_t cctor_thread;
+ GenericContainerIndex genericContainerIndex;
+ CustomAttributeIndex customAttributeIndex;
+ uint32_t instance_size;
+ uint32_t actualSize;
+ uint32_t element_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+ int32_t thread_static_fields_offset;
+ uint32_t flags;
+ uint32_t token;
+ uint16_t method_count;
+ uint16_t property_count;
+ uint16_t field_count;
+ uint16_t event_count;
+ uint16_t nested_type_count;
+ uint16_t vtable_count;
+ uint16_t interfaces_count;
+ uint16_t interface_offsets_count;
+ uint8_t typeHierarchyDepth;
+ uint8_t rank;
+ uint8_t minimumAlignment;
+ uint8_t packingSize;
+ uint8_t valuetype : 1;
+ uint8_t initialized : 1;
+ uint8_t enumtype : 1;
+ uint8_t is_generic : 1;
+ uint8_t has_references : 1;
+ uint8_t init_pending : 1;
+ uint8_t size_inited : 1;
+ uint8_t has_finalize : 1;
+ uint8_t has_cctor : 1;
+ uint8_t is_blittable : 1;
+ uint8_t is_import_or_windows_runtime : 1;
+ uint8_t is_vtable_initialized : 1;
+};
+struct Il2CppClass {
+ struct Il2CppClass_0 _0;
+ Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+ void* static_fields;
+ const Il2CppRGCTXData* rgctx_data;
+ struct Il2CppClass_1 _1;
+ VirtualInvokeData vtable[32];
+};
+struct Il2CppTypeDefinitionSizes
+{
+ uint32_t instance_size;
+ int32_t native_size;
+ uint32_t static_fields_size;
+ uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+ Il2CppAppDomain* domain;
+ Il2CppAppDomainSetup* setup;
+ Il2CppAppContext* default_context;
+ const char* friendly_name;
+ uint32_t domain_id;
+};
+struct Il2CppImage
+{
+ const char* name;
+ AssemblyIndex assemblyIndex;
+ TypeDefinitionIndex typeStart;
+ uint32_t typeCount;
+ MethodIndex entryPointIndex;
+ Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+ uint32_t token;
+};
+struct Il2CppMarshalingFunctions
+{
+ Il2CppMethodPointer marshal_to_native_func;
+ Il2CppMethodPointer marshal_from_native_func;
+ Il2CppMethodPointer marshal_cleanup_func;
+};
+struct Il2CppCodeGenOptions
+{
+ bool enablePrimitiveValueTypeGenericSharing;
+};
+struct Il2CppCodeRegistration
+{
+ uint32_t methodPointersCount;
+ const Il2CppMethodPointer* methodPointers;
+ uint32_t reversePInvokeWrapperCount;
+ const Il2CppMethodPointer* reversePInvokeWrappers;
+ uint32_t delegateWrappersFromManagedToNativeCount;
+ const Il2CppMethodPointer* delegateWrappersFromManagedToNative;
+ uint32_t marshalingFunctionsCount;
+ const Il2CppMarshalingFunctions* marshalingFunctions;
+ uint32_t ccwMarshalingFunctionsCount;
+ const Il2CppMethodPointer* ccwMarshalingFunctions;
+ uint32_t genericMethodPointersCount;
+ const Il2CppMethodPointer* genericMethodPointers;
+ uint32_t invokerPointersCount;
+ const InvokerMethod* invokerPointers;
+ CustomAttributeIndex customAttributeCount;
+ const CustomAttributesCacheGenerator* customAttributeGenerators;
+ GuidIndex guidCount;
+ const Il2CppGuid** guids;
+ uint32_t unresolvedVirtualCallCount;
+ const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+};
+struct Il2CppMetadataRegistration
+{
+ int32_t genericClassesCount;
+ Il2CppGenericClass* const * genericClasses;
+ int32_t genericInstsCount;
+ const Il2CppGenericInst* const * genericInsts;
+ int32_t genericMethodTableCount;
+ const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+ int32_t typesCount;
+ const Il2CppType* const * types;
+ int32_t methodSpecsCount;
+ const Il2CppMethodSpec* methodSpecs;
+ FieldIndex fieldOffsetsCount;
+ const int32_t** fieldOffsets;
+ TypeDefinitionIndex typeDefinitionsSizesCount;
+ const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+ const size_t metadataUsagesCount;
+ void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+ uint64_t new_object_count;
+ uint64_t initialized_class_count;
+ uint64_t method_count;
+ uint64_t class_static_data_size;
+ uint64_t generic_instance_count;
+ uint64_t generic_class_count;
+ uint64_t inflated_method_count;
+ uint64_t inflated_type_count;
+ bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppPerfCounters
+{
+ uint32_t jit_methods;
+ uint32_t jit_bytes;
+ uint32_t jit_time;
+ uint32_t jit_failures;
+ uint32_t exceptions_thrown;
+ uint32_t exceptions_filters;
+ uint32_t exceptions_finallys;
+ uint32_t exceptions_depth;
+ uint32_t aspnet_requests_queued;
+ uint32_t aspnet_requests;
+ uint32_t gc_collections0;
+ uint32_t gc_collections1;
+ uint32_t gc_collections2;
+ uint32_t gc_promotions0;
+ uint32_t gc_promotions1;
+ uint32_t gc_promotion_finalizers;
+ uint32_t gc_gen0size;
+ uint32_t gc_gen1size;
+ uint32_t gc_gen2size;
+ uint32_t gc_lossize;
+ uint32_t gc_fin_survivors;
+ uint32_t gc_num_handles;
+ uint32_t gc_allocated;
+ uint32_t gc_induced;
+ uint32_t gc_time;
+ uint32_t gc_total_bytes;
+ uint32_t gc_committed_bytes;
+ uint32_t gc_reserved_bytes;
+ uint32_t gc_num_pinned;
+ uint32_t gc_sync_blocks;
+ uint32_t remoting_calls;
+ uint32_t remoting_channels;
+ uint32_t remoting_proxies;
+ uint32_t remoting_classes;
+ uint32_t remoting_objects;
+ uint32_t remoting_contexts;
+ uint32_t loader_classes;
+ uint32_t loader_total_classes;
+ uint32_t loader_appdomains;
+ uint32_t loader_total_appdomains;
+ uint32_t loader_assemblies;
+ uint32_t loader_total_assemblies;
+ uint32_t loader_failures;
+ uint32_t loader_bytes;
+ uint32_t loader_appdomains_uloaded;
+ uint32_t thread_contentions;
+ uint32_t thread_queue_len;
+ uint32_t thread_queue_max;
+ uint32_t thread_num_logical;
+ uint32_t thread_num_physical;
+ uint32_t thread_cur_recognized;
+ uint32_t thread_num_recognized;
+ uint32_t interop_num_ccw;
+ uint32_t interop_num_stubs;
+ uint32_t interop_num_marshals;
+ uint32_t security_num_checks;
+ uint32_t security_num_link_checks;
+ uint32_t security_time;
+ uint32_t security_depth;
+ uint32_t unused;
+ uint64_t threadpool_workitems;
+ uint64_t threadpool_ioworkitems;
+ unsigned int threadpool_threads;
+ unsigned int threadpool_iothreads;
+};
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct Il2CppIUnknown;
+struct Il2CppWaitHandle;
+struct MonitorData;
+struct VirtualInvokeData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+ Il2CppClass *klass;
+ MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+ il2cpp_array_size_t length;
+ il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+ Il2CppObject object;
+ int32_t length;
+ Il2CppChar chars [32];
+};
+struct Il2CppReflectionType {
+ Il2CppObject object;
+ const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType
+{
+ Il2CppReflectionType type;
+ Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent {
+ Il2CppObject object;
+ Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+ Il2CppReflectionEvent event;
+ Il2CppReflectionType* reflectedType;
+ const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+ Il2CppReflectionType* declaringType;
+ Il2CppReflectionType* reflectedType;
+ Il2CppString* name;
+ Il2CppReflectionMethod* addMethod;
+ Il2CppReflectionMethod* removeMethod;
+ Il2CppReflectionMethod* raiseMethod;
+ uint32_t eventAttributes;
+ Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo {
+ Il2CppReflectionType *utype;
+ Il2CppArray *values;
+ Il2CppArray *names;
+ void* name_hash;
+};
+struct Il2CppReflectionField {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ FieldInfo *field;
+ Il2CppString *name;
+ Il2CppReflectionType *type;
+ uint32_t attrs;
+};
+struct Il2CppReflectionProperty {
+ Il2CppObject object;
+ Il2CppClass *klass;
+ const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod {
+ Il2CppObject object;
+ const MethodInfo *method;
+ Il2CppString *name;
+ Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+ Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo {
+ Il2CppReflectionType *parent;
+ Il2CppReflectionType *ret;
+ uint32_t attrs;
+ uint32_t implattrs;
+ uint32_t callconv;
+};
+struct Il2CppPropertyInfo {
+ Il2CppReflectionType* parent;
+ Il2CppString *name;
+ Il2CppReflectionMethod *get;
+ Il2CppReflectionMethod *set;
+ uint32_t attrs;
+};
+struct Il2CppReflectionParameter{
+ Il2CppObject object;
+ Il2CppReflectionType *ClassImpl;
+ Il2CppObject *DefaultValueImpl;
+ Il2CppObject *MemberImpl;
+ Il2CppString *NameImpl;
+ int32_t PositionImpl;
+ uint32_t AttrsImpl;
+ Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+ Il2CppObject obj;
+ const Il2CppImage* image;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* fqname;
+ Il2CppString* name;
+ Il2CppString* scopename;
+ bool is_resource;
+ uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+ Il2CppObject obj;
+ Il2CppString *name;
+ Il2CppString *codebase;
+ int32_t major, minor, build, revision;
+ Il2CppObject *cultureInfo;
+ uint32_t flags;
+ uint32_t hashalg;
+ Il2CppObject *keypair;
+ Il2CppArray *publicKey;
+ Il2CppArray *keyToken;
+ uint32_t versioncompat;
+ Il2CppObject *version;
+ uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly {
+ Il2CppObject object;
+ const Il2CppAssembly *assembly;
+ Il2CppObject *resolve_event_holder;
+ Il2CppObject *evidence;
+ Il2CppObject *minimum;
+ Il2CppObject *optional;
+ Il2CppObject *refuse;
+ Il2CppObject *granted;
+ Il2CppObject *denied;
+ bool from_byte_array;
+ Il2CppString *name;
+};
+struct Il2CppReflectionMarshal {
+ Il2CppObject object;
+ int32_t count;
+ int32_t type;
+ int32_t eltype;
+ Il2CppString* guid;
+ Il2CppString* mcookie;
+ Il2CppString* marshaltype;
+ Il2CppObject* marshaltyperef;
+ int32_t param_num;
+ bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+ Il2CppObject object;
+ void* data;
+ Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+ void* m_value;
+};
+struct Il2CppAppDomainSetup {
+ Il2CppObject object;
+ Il2CppString* application_base;
+ Il2CppString* application_name;
+ Il2CppString* cache_path;
+ Il2CppString* configuration_file;
+ Il2CppString* dynamic_base;
+ Il2CppString* license_file;
+ Il2CppString* private_bin_path;
+ Il2CppString* private_bin_path_probe;
+ Il2CppString* shadow_copy_directories;
+ Il2CppString* shadow_copy_files;
+ uint8_t publisher_policy;
+ uint8_t path_changed;
+ int loader_optimization;
+ uint8_t disallow_binding_redirects;
+ uint8_t disallow_code_downloads;
+ Il2CppObject* activation_arguments;
+ Il2CppObject* domain_initializer;
+ Il2CppObject* application_trust;
+ Il2CppArray* domain_initializer_args;
+ uint8_t disallow_appbase_probe;
+ Il2CppArray* configuration_bytes;
+};
+struct Il2CppException {
+ Il2CppObject object;
+ Il2CppArray *trace_ips;
+ Il2CppException *inner_ex;
+ Il2CppString *message;
+ Il2CppString *help_link;
+ Il2CppString *class_name;
+ Il2CppString *stack_trace;
+ Il2CppString *remote_stack_trace;
+ int32_t remote_stack_index;
+ il2cpp_hresult_t hresult;
+ Il2CppString *source;
+ Il2CppObject *_data;
+};
+struct Il2CppSystemException {
+ Il2CppException base;
+};
+struct Il2CppArgumentException {
+ Il2CppException base;
+ Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+ Il2CppType *type;
+ void* value;
+ Il2CppClass *klass;
+};
+struct Il2CppDelegate {
+ Il2CppObject object;
+ Il2CppMethodPointer method_ptr;
+ void* (*invoke_impl)(const MethodInfo*, void*, void**);
+ Il2CppObject *target;
+ const MethodInfo *method;
+ void* delegate_trampoline;
+ uint8_t **method_code;
+ Il2CppReflectionMethod *method_info;
+ Il2CppReflectionMethod *original_method_info;
+ Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject {
+ Il2CppObject obj;
+ Il2CppObject *identity;
+};
+struct Il2CppComObject
+{
+ Il2CppObject obj;
+ Il2CppIUnknown* identity;
+};
+struct Il2CppAppDomain {
+ Il2CppMarshalByRefObject mbr;
+ Il2CppDomain *data;
+};
+struct Il2CppStackFrame {
+ Il2CppObject obj;
+ int32_t il_offset;
+ int32_t native_offset;
+ Il2CppReflectionMethod *method;
+ Il2CppString *filename;
+ int32_t line;
+ int32_t column;
+ Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* AMDesignator;
+ Il2CppString* PMDesignator;
+ Il2CppString* DateSeparator;
+ Il2CppString* TimeSeparator;
+ Il2CppString* ShortDatePattern;
+ Il2CppString* LongDatePattern;
+ Il2CppString* ShortTimePattern;
+ Il2CppString* LongTimePattern;
+ Il2CppString* MonthDayPattern;
+ Il2CppString* YearMonthPattern;
+ Il2CppString* FullDateTimePattern;
+ Il2CppString* RFC1123Pattern;
+ Il2CppString* SortableDateTimePattern;
+ Il2CppString* UniversalSortableDateTimePattern;
+ uint32_t FirstDayOfWeek;
+ Il2CppObject* Calendar;
+ uint32_t CalendarWeekRule;
+ Il2CppArray* AbbreviatedDayNames;
+ Il2CppArray* DayNames;
+ Il2CppArray* MonthNames;
+ Il2CppArray* AbbreviatedMonthNames;
+ Il2CppArray* ShortDatePatterns;
+ Il2CppArray* LongDatePatterns;
+ Il2CppArray* ShortTimePatterns;
+ Il2CppArray* LongTimePatterns;
+ Il2CppArray* MonthDayPatterns;
+ Il2CppArray* YearMonthPatterns;
+ Il2CppArray* ShortDayNames;
+};
+struct Il2CppNumberFormatInfo {
+ Il2CppObject obj;
+ bool readOnly;
+ Il2CppString* decimalFormats;
+ Il2CppString* currencyFormats;
+ Il2CppString* percentFormats;
+ Il2CppString* digitPattern;
+ Il2CppString* zeroPattern;
+ int32_t currencyDecimalDigits;
+ Il2CppString* currencyDecimalSeparator;
+ Il2CppString* currencyGroupSeparator;
+ Il2CppArray* currencyGroupSizes;
+ int32_t currencyNegativePattern;
+ int32_t currencyPositivePattern;
+ Il2CppString* currencySymbol;
+ Il2CppString* naNSymbol;
+ Il2CppString* negativeInfinitySymbol;
+ Il2CppString* negativeSign;
+ uint32_t numberDecimalDigits;
+ Il2CppString* numberDecimalSeparator;
+ Il2CppString* numberGroupSeparator;
+ Il2CppArray* numberGroupSizes;
+ int32_t numberNegativePattern;
+ int32_t percentDecimalDigits;
+ Il2CppString* percentDecimalSeparator;
+ Il2CppString* percentGroupSeparator;
+ Il2CppArray* percentGroupSizes;
+ int32_t percentNegativePattern;
+ int32_t percentPositivePattern;
+ Il2CppString* percentSymbol;
+ Il2CppString* perMilleSymbol;
+ Il2CppString* positiveInfinitySymbol;
+ Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo {
+ Il2CppObject obj;
+ bool is_read_only;
+ int32_t lcid;
+ int32_t parent_lcid;
+ int32_t specific_lcid;
+ int32_t datetime_index;
+ int32_t number_index;
+ bool use_user_override;
+ Il2CppNumberFormatInfo* number_format;
+ Il2CppDateTimeFormatInfo* datetime_format;
+ Il2CppObject* textinfo;
+ Il2CppString* name;
+ Il2CppString* displayname;
+ Il2CppString* englishname;
+ Il2CppString* nativename;
+ Il2CppString* iso3lang;
+ Il2CppString* iso2lang;
+ Il2CppString* icu_name;
+ Il2CppString* win3lang;
+ Il2CppString* territory;
+ Il2CppString* compareinfo;
+ const int32_t* calendar_data;
+ const void* text_info_data;
+};
+struct Il2CppSafeHandle
+{
+ Il2CppObject base;
+ void* handle;
+ void* invalid_handle_value;
+ int refcount;
+ bool owns_handle;
+};
+struct Il2CppStringBuilder
+{
+ Il2CppObject object;
+ int32_t length;
+ Il2CppString *str;
+ Il2CppString *cached_str;
+ int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+ Il2CppObject base;
+ Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+ Il2CppObject base;
+ Il2CppString *str;
+ int32_t options;
+ Il2CppArray *key;
+ int32_t lcid;
+};
+struct Il2CppErrorWrapper
+{
+ Il2CppObject base;
+ int32_t errorCode;
+};
+struct Il2CppAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *async_state;
+ Il2CppWaitHandle *handle;
+ Il2CppDelegate *async_delegate;
+ void* data;
+ Il2CppAsyncCall *object_data;
+ bool sync_completed;
+ bool completed;
+ bool endinvoke_called;
+ Il2CppObject *async_callback;
+ Il2CppObject *execution_context;
+ Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+ Il2CppObject base;
+ void *msg;
+ MethodInfo *cb_method;
+ Il2CppDelegate *cb_target;
+ Il2CppObject *state;
+ Il2CppObject *res;
+ Il2CppArray *out_args;
+ uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+ Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+ Il2CppObject base;
+ Il2CppObject *socket;
+ Il2CppIntPtr handle;
+ Il2CppObject *state;
+ Il2CppDelegate *callback;
+ Il2CppWaitHandle *wait_handle;
+ Il2CppException *delayedException;
+ Il2CppObject *ep;
+ Il2CppArray *buffer;
+ int32_t offset;
+ int32_t size;
+ int32_t socket_flags;
+ Il2CppObject *accept_reuse_socket;
+ Il2CppArray *addresses;
+ int32_t port;
+ Il2CppObject *buffers;
+ bool reusesocket;
+ Il2CppObject *acceptSocket;
+ int32_t total;
+ bool completed_synchronously;
+ bool completed;
+ bool blocking;
+ int32_t error;
+ int32_t operation;
+ Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+ RESOURCE_LOCATION_EMBEDDED = 1,
+ RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+ RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+ Il2CppObject object;
+ Il2CppReflectionAssembly* assembly;
+ Il2CppString* filename;
+ uint32_t location;
+};
+struct Il2CppAppContext
+{
+ Il2CppObject obj;
+ int32_t domain_id;
+ int32_t context_id;
+ void* static_data;
+};
+typedef struct
+{
+ union {
+  uint32_t ss32;
+  struct signscale {
+   unsigned int reserved1 : 16;
+   unsigned int scale : 8;
+   unsigned int reserved2 : 7;
+   unsigned int sign : 1;
+  } signscale;
+ } u;
+ uint32_t hi32;
+ uint32_t lo32;
+ uint32_t mid32;
+} il2cpp_decimal_repr;

--- a/Il2CppInspector.Common/Outputs/Data/23-5.6.2p3.i
+++ b/Il2CppInspector.Common/Outputs/Data/23-5.6.2p3.i
@@ -1,0 +1,1532 @@
+typedef uint16_t Il2CppChar;
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+const Il2CppChar kIl2CppNewLine[] = { '\n', '\0' };
+enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType(EncodedMethodIndex index)
+{
+    return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex(EncodedMethodIndex index)
+{
+    return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD
+};
+struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    CustomAttributeIndex customAttributeIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+};
+struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeIndex;
+    TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    CustomAttributeIndex customAttributeIndex;
+    GenericContainerIndex genericContainerIndex;
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex reversePInvokeWrapperIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+};
+struct Il2CppAssembly
+{
+    ImageIndex imageIndex;
+    CustomAttributeIndex customAttributeIndex;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+};
+struct Il2CppCustomAttributeTypeRange
+{
+    int32_t start;
+    int32_t count;
+};
+struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+};
+struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t rgctxEntriesOffset;
+    int32_t rgctxEntriesCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+};
+struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+};
+struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+};
+typedef enum
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+    FRAME_TYPE_MANAGED = 0,
+    FRAME_TYPE_DEBUGGER_INVOKE = 1,
+    FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+    FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+};
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef int32_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct Il2CppGuid;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppAppDomainSetup;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+};
+enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *enum_info_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+    int count;
+    Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    CustomAttributeIndex customAttributeIndex;
+    const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+};
+struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *declaring_type;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+};
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+};
+struct Il2CppClass_0
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    const Il2CppType* byval_arg;
+    const Il2CppType* this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+    Il2CppClass** typeHierarchy;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t __padding;
+#endif
+    uint64_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t packingSize;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+};
+struct Il2CppClass {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+};
+struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+};
+struct Il2CppImage
+{
+    const char* name;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+    uint32_t token;
+};
+struct Il2CppCodeGenOptions
+{
+    bool enablePrimitiveValueTypeGenericSharing;
+};
+struct Il2CppCodeRegistration
+{
+    uint32_t methodPointersCount;
+    const Il2CppMethodPointer* methodPointers;
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+};
+struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+    uint64_t new_object_count;
+    uint64_t initialized_class_count;
+    uint64_t method_count;
+    uint64_t class_static_data_size;
+    uint64_t generic_instance_count;
+    uint64_t generic_class_count;
+    uint64_t inflated_method_count;
+    uint64_t inflated_type_count;
+    bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+};
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct Il2CppIUnknown;
+struct Il2CppWaitHandle;
+struct MonitorData;
+struct VirtualInvokeData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+    Il2CppClass *klass;
+    MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+};
+struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo
+{
+    Il2CppReflectionType *utype;
+    Il2CppArray *values;
+    Il2CppArray *names;
+    void* name_hash;
+};
+struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+};
+struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+};
+struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+};
+struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    bool is_resource;
+    uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    bool from_byte_array;
+    Il2CppString *name;
+};
+struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+};
+struct Il2CppIntPtr
+{
+    void* m_value;
+};
+struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+};
+struct Il2CppException
+{
+    Il2CppObject obj;
+    Il2CppArray *trace_ips;
+    Il2CppException *inner_ex;
+    Il2CppString *message;
+    Il2CppString *help_link;
+    Il2CppString *class_name;
+    Il2CppString *stack_trace;
+    Il2CppString *remote_stack_trace;
+    int32_t remote_stack_index;
+    il2cpp_hresult_t hresult;
+    Il2CppString *source;
+    Il2CppObject *_data;
+};
+struct Il2CppSystemException
+{
+    Il2CppException base;
+};
+struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+    Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+};
+struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    void* (*invoke_impl)(const MethodInfo*, void*, void**);
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+};
+struct Il2CppComObject
+{
+    Il2CppObject obj;
+    Il2CppIUnknown* identity;
+};
+struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+};
+struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    bool readOnly;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* TimeSeparator;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* FullDateTimePattern;
+    Il2CppString* RFC1123Pattern;
+    Il2CppString* SortableDateTimePattern;
+    Il2CppString* UniversalSortableDateTimePattern;
+    uint32_t FirstDayOfWeek;
+    Il2CppObject* Calendar;
+    uint32_t CalendarWeekRule;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* MonthDayPatterns;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDayNames;
+};
+struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    bool readOnly;
+    Il2CppString* decimalFormats;
+    Il2CppString* currencyFormats;
+    Il2CppString* percentFormats;
+    Il2CppString* digitPattern;
+    Il2CppString* zeroPattern;
+    int32_t currencyDecimalDigits;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppArray* currencyGroupSizes;
+    int32_t currencyNegativePattern;
+    int32_t currencyPositivePattern;
+    Il2CppString* currencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* negativeSign;
+    uint32_t numberDecimalDigits;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppArray* numberGroupSizes;
+    int32_t numberNegativePattern;
+    int32_t percentDecimalDigits;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppArray* percentGroupSizes;
+    int32_t percentNegativePattern;
+    int32_t percentPositivePattern;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    bool is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t specific_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    bool use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* displayname;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* icu_name;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppString* compareinfo;
+    const int32_t* calendar_data;
+    const void* text_info_data;
+};
+struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t lcid;
+    int32_t region_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+};
+struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    void* invalid_handle_value;
+    int refcount;
+    bool owns_handle;
+};
+struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppString *str;
+    Il2CppString *cached_str;
+    int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    int32_t options;
+    Il2CppArray *key;
+    int32_t lcid;
+};
+struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+};
+struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    bool sync_completed;
+    bool completed;
+    bool endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    void *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+    uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *socket;
+    Il2CppIntPtr handle;
+    Il2CppObject *state;
+    Il2CppDelegate *callback;
+    Il2CppWaitHandle *wait_handle;
+    Il2CppException *delayedException;
+    Il2CppObject *ep;
+    Il2CppArray *buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject *accept_reuse_socket;
+    Il2CppArray *addresses;
+    int32_t port;
+    Il2CppObject *buffers;
+    bool reusesocket;
+    Il2CppObject *acceptSocket;
+    int32_t total;
+    bool completed_synchronously;
+    bool completed;
+    bool blocking;
+    int32_t error;
+    int32_t operation;
+    Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+    RESOURCE_LOCATION_EMBEDDED = 1,
+    RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+};
+struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+};
+typedef struct
+{
+    union
+    {
+        uint32_t ss32;
+        struct signscale
+        {
+            unsigned int reserved1 : 16;
+            unsigned int scale : 8;
+            unsigned int reserved2 : 7;
+            unsigned int sign : 1;
+        } signscale;
+    } u;
+    uint32_t hi32;
+    uint32_t lo32;
+    uint32_t mid32;
+} il2cpp_decimal_repr;

--- a/Il2CppInspector.Common/Outputs/Data/24.0-2017.2f3.i
+++ b/Il2CppInspector.Common/Outputs/Data/24.0-2017.2f3.i
@@ -1,0 +1,1534 @@
+typedef uint16_t Il2CppChar;
+typedef uint32_t Il2CppMethodSlot;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+const Il2CppChar kIl2CppNewLine[] = { '\n', '\0' };
+enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+};
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+};
+static inline Il2CppMetadataUsage GetEncodedIndexType(EncodedMethodIndex index)
+{
+    return (Il2CppMetadataUsage)((index & 0xE0000000) >> 29);
+}
+static inline uint32_t GetDecodedMethodIndex(EncodedMethodIndex index)
+{
+    return index & 0x1FFFFFFFU;
+}
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+};
+enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+};
+struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+};
+struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+};
+struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    CustomAttributeIndex customAttributeIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+};
+struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+};
+struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+};
+struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+};
+struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeIndex;
+    TypeIndex typeIndex;
+};
+struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+};
+struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    CustomAttributeIndex customAttributeIndex;
+    GenericContainerIndex genericContainerIndex;
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex reversePInvokeWrapperIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+};
+struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+};
+struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+};
+struct Il2CppGenericMethodIndices
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+};
+struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+};
+struct Il2CppAssemblyName
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t publicKeyToken[8];
+};
+struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+};
+struct Il2CppAssembly
+{
+    ImageIndex imageIndex;
+    CustomAttributeIndex customAttributeIndex;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+};
+struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+};
+struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+};
+struct Il2CppCustomAttributeTypeRange
+{
+    int32_t start;
+    int32_t count;
+};
+struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+};
+struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+};
+#pragma pack(push, p1,4)
+struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t rgctxEntriesOffset;
+    int32_t rgctxEntriesCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+};
+#pragma pack(pop, p1)
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+};
+struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+};
+struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+};
+struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+};
+struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+};
+struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+};
+struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+};
+struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+};
+typedef enum
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE
+};
+struct Il2CppClass;
+struct Il2CppType;
+struct EventInfo;
+struct MethodInfo;
+struct FieldInfo;
+struct PropertyInfo;
+struct Il2CppAssembly;
+struct Il2CppArray;
+struct Il2CppDelegate;
+struct Il2CppDomain;
+struct Il2CppImage;
+struct Il2CppException;
+struct Il2CppProfiler;
+struct Il2CppObject;
+struct Il2CppReflectionMethod;
+struct Il2CppReflectionType;
+struct Il2CppString;
+struct Il2CppAsyncResult;
+enum Il2CppProfileFlags
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19
+};
+enum Il2CppGCEvent
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+};
+enum Il2CppStat
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+};
+enum StackFrameType
+{
+    FRAME_TYPE_MANAGED = 0,
+    FRAME_TYPE_DEBUGGER_INVOKE = 1,
+    FRAME_TYPE_MANAGED_TO_NATIVE = 2,
+    FRAME_TYPE_SENTINEL = 3
+};
+enum Il2CppRuntimeUnhandledExceptionPolicy
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+};
+struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+};
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef uintptr_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct Il2CppGuid;
+struct Il2CppImage;
+struct Il2CppAssembly;
+struct Il2CppAppDomain;
+struct Il2CppAppDomainSetup;
+struct Il2CppDelegate;
+struct Il2CppAppContext;
+struct Il2CppNameToTypeDefinitionIndexHashTable;
+struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+};
+enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+};
+extern bool g_il2cpp_is_fully_initialized;
+typedef struct
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *enum_info_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+};
+struct CustomAttributeTypeCache
+{
+    int count;
+    Il2CppClass** attributeTypes;
+};
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+};
+struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    CustomAttributeIndex customAttributeIndex;
+    const Il2CppType* parameter_type;
+};
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+};
+struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *declaring_type;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+};
+struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+};
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+};
+struct Il2CppClass_0
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    const Il2CppType* byval_arg;
+    const Il2CppType* this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+};
+struct Il2CppClass_1
+{
+    Il2CppClass** typeHierarchy;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t __padding;
+#endif
+     uint64_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    CustomAttributeIndex customAttributeIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t packingSize;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+};
+struct Il2CppClass {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+};
+struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+};
+struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+};
+struct Il2CppImage
+{
+    const char* name;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable* nameToClassHashTable;
+    uint32_t token;
+};
+struct Il2CppCodeGenOptions
+{
+    bool enablePrimitiveValueTypeGenericSharing;
+};
+struct Il2CppCodeRegistration
+{
+    uint32_t methodPointersCount;
+    const Il2CppMethodPointer* methodPointers;
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+};
+struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+};
+struct Il2CppRuntimeStats
+{
+    uint64_t new_object_count;
+    uint64_t initialized_class_count;
+    uint64_t method_count;
+    uint64_t class_static_data_size;
+    uint64_t generic_instance_count;
+    uint64_t generic_class_count;
+    uint64_t inflated_method_count;
+    uint64_t inflated_type_count;
+    bool enabled;
+};
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+};
+struct Il2CppClass;
+struct MethodInfo;
+struct PropertyInfo;
+struct FieldInfo;
+struct EventInfo;
+struct Il2CppType;
+struct Il2CppAssembly;
+struct Il2CppException;
+struct Il2CppImage;
+struct Il2CppDomain;
+struct Il2CppString;
+struct Il2CppReflectionMethod;
+struct Il2CppAsyncCall;
+struct Il2CppIUnknown;
+struct Il2CppWaitHandle;
+struct MonitorData;
+struct Il2CppReflectionAssembly;
+struct Il2CppObject
+{
+    Il2CppClass *klass;
+    MonitorData *monitor;
+};
+typedef int32_t il2cpp_array_lower_bound_t;
+struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+};
+struct Il2CppArray
+{
+ Il2CppObject obj;
+ Il2CppArrayBounds *bounds;
+ il2cpp_array_size_t max_length;
+ double vector [32];
+};
+struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+};
+struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+};
+struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+};
+struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+};
+struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+};
+struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+};
+struct Il2CppEnumInfo
+{
+    Il2CppReflectionType *utype;
+    Il2CppArray *values;
+    Il2CppArray *names;
+    void* name_hash;
+};
+struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+};
+struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+};
+struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+};
+struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+};
+struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+};
+struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+};
+struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+};
+struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    bool is_resource;
+    uint32_t token;
+};
+struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+};
+struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    bool from_byte_array;
+    Il2CppString *name;
+};
+struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    bool has_size;
+};
+struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+};
+struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+};
+struct Il2CppException
+{
+    Il2CppObject obj;
+    Il2CppArray *trace_ips;
+    Il2CppException *inner_ex;
+    Il2CppString *message;
+    Il2CppString *help_link;
+    Il2CppString *class_name;
+    Il2CppString *stack_trace;
+    Il2CppString *remote_stack_trace;
+    int32_t remote_stack_index;
+    il2cpp_hresult_t hresult;
+    Il2CppString *source;
+    Il2CppObject *_data;
+};
+struct Il2CppSystemException
+{
+    Il2CppException base;
+};
+struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+};
+struct Il2CppTypedRef
+{
+    Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+};
+struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+};
+struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+};
+struct Il2CppComObject
+{
+    Il2CppObject obj;
+    Il2CppIUnknown* identity;
+};
+struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+};
+struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+};
+struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    bool readOnly;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* TimeSeparator;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* FullDateTimePattern;
+    Il2CppString* RFC1123Pattern;
+    Il2CppString* SortableDateTimePattern;
+    Il2CppString* UniversalSortableDateTimePattern;
+    uint32_t FirstDayOfWeek;
+    Il2CppObject* Calendar;
+    uint32_t CalendarWeekRule;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* MonthDayPatterns;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDayNames;
+};
+struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    bool readOnly;
+    Il2CppString* decimalFormats;
+    Il2CppString* currencyFormats;
+    Il2CppString* percentFormats;
+    Il2CppString* digitPattern;
+    Il2CppString* zeroPattern;
+    int32_t currencyDecimalDigits;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppArray* currencyGroupSizes;
+    int32_t currencyNegativePattern;
+    int32_t currencyPositivePattern;
+    Il2CppString* currencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* negativeSign;
+    uint32_t numberDecimalDigits;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppArray* numberGroupSizes;
+    int32_t numberNegativePattern;
+    int32_t percentDecimalDigits;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppArray* percentGroupSizes;
+    int32_t percentNegativePattern;
+    int32_t percentPositivePattern;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* positiveSign;
+};
+struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    bool is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t specific_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    bool use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* displayname;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* icu_name;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppString* compareinfo;
+    const int32_t* calendar_data;
+    const void* text_info_data;
+};
+struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t lcid;
+    int32_t region_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+};
+struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    void* invalid_handle_value;
+    int refcount;
+    bool owns_handle;
+};
+struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppString *str;
+    Il2CppString *cached_str;
+    int32_t max_capacity;
+};
+struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    Il2CppArray* data;
+};
+struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    int32_t options;
+    Il2CppArray *key;
+    int32_t lcid;
+};
+struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+};
+struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    bool sync_completed;
+    bool completed;
+    bool endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+};
+struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    void *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+    uint64_t wait_event;
+};
+struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+};
+struct Il2CppSocketAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *socket;
+    intptr_t handle;
+    Il2CppObject *state;
+    Il2CppDelegate *callback;
+    Il2CppWaitHandle *wait_handle;
+    Il2CppException *delayedException;
+    Il2CppObject *ep;
+    Il2CppArray *buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject *accept_reuse_socket;
+    Il2CppArray *addresses;
+    int32_t port;
+    Il2CppObject *buffers;
+    bool reusesocket;
+    Il2CppObject *acceptSocket;
+    int32_t total;
+    bool completed_synchronously;
+    bool completed;
+    bool blocking;
+    int32_t error;
+    int32_t operation;
+    Il2CppAsyncResult *ares;
+};
+enum Il2CppResourceLocation
+{
+    RESOURCE_LOCATION_EMBEDDED = 1,
+    RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    RESOURCE_LOCATION_IN_MANIFEST = 4
+};
+struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+};
+struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+};
+typedef struct
+{
+    union
+    {
+        uint32_t ss32;
+        struct signscale
+        {
+            unsigned int reserved1 : 16;
+            unsigned int scale : 8;
+            unsigned int reserved2 : 7;
+            unsigned int sign : 1;
+        } signscale;
+    } u;
+    uint32_t hi32;
+    uint32_t lo32;
+    uint32_t mid32;
+} il2cpp_decimal_repr;

--- a/Il2CppInspector.Common/Outputs/Data/24.1-2018.3.0f2.i
+++ b/Il2CppInspector.Common/Outputs/Data/24.1-2018.3.0f2.i
@@ -1,0 +1,1638 @@
+typedef uint16_t Il2CppChar;
+typedef uint32_t Il2CppMethodSlot;
+const uint32_t kInvalidIl2CppMethodSlot = 65535;
+const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+const Il2CppChar kIl2CppNewLine[] = { '\n', '\0' };
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+const TypeIndex kTypeIndexInvalid = -1;
+const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+const EventIndex kEventIndexInvalid = -1;
+const FieldIndex kFieldIndexInvalid = -1;
+const MethodIndex kMethodIndexInvalid = -1;
+const PropertyIndex kPropertyIndexInvalid = -1;
+const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+const RGCTXIndex kRGCTXIndexInvalid = -1;
+const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+};
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+    MethodIndex reversePInvokeWrapperIndex;
+    RGCTXIndex rgctxStartIndex;
+    int32_t rgctxCount;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t rgctxEntriesOffset;
+    int32_t rgctxEntriesCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef uintptr_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *enum_info_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+const int THREAD_STATIC_FIELD_OFFSET = -1;
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int8_t tableIndex;
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t codeSize;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointIndex
+{
+    uint8_t tableIndex;
+    int32_t index;
+} Il2CppSequencePointIndex;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    uint8_t isActive;
+    int32_t id;
+    uint8_t tryDepth;
+} Il2CppSequencePoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo** methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePointIndex* sequencePointIndexes;
+    Il2CppSequencePoint** sequencePoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass_0
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+typedef struct Il2CppClass_1
+{
+    Il2CppClass** typeHierarchy;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+#ifdef IS_32BIT
+    uint32_t __padding;
+#endif
+    uint64_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+typedef struct Il2CppClass {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t methodPointersCount;
+    const Il2CppMethodPointer* methodPointers;
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppRuntimeStats
+{
+    uint64_t new_object_count;
+    uint64_t initialized_class_count;
+    uint64_t method_count;
+    uint64_t class_static_data_size;
+    uint64_t generic_instance_count;
+    uint64_t generic_class_count;
+    uint64_t inflated_method_count;
+    uint64_t inflated_type_count;
+    uint8_t enabled;
+} Il2CppRuntimeStats;
+extern Il2CppRuntimeStats il2cpp_runtime_stats;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+void il2cpp_gc_wbarrier_set_field(Il2CppObject * obj, void **targetAddress, void *object);
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppEnumInfo
+{
+    Il2CppReflectionType *utype;
+    Il2CppArray *values;
+    Il2CppArray *names;
+    void* name_hash;
+} Il2CppEnumInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppArray *trace_ips;
+    Il2CppException *inner_ex;
+    Il2CppString *message;
+    Il2CppString *help_link;
+    Il2CppString *class_name;
+    Il2CppString *stack_trace;
+    Il2CppString *remote_stack_trace;
+    int32_t remote_stack_index;
+    il2cpp_hresult_t hresult;
+    Il2CppString *source;
+    Il2CppObject *_data;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+} Il2CppDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    uint8_t readOnly;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* TimeSeparator;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* FullDateTimePattern;
+    Il2CppString* RFC1123Pattern;
+    Il2CppString* SortableDateTimePattern;
+    Il2CppString* UniversalSortableDateTimePattern;
+    uint32_t FirstDayOfWeek;
+    Il2CppObject* Calendar;
+    uint32_t CalendarWeekRule;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* MonthDayPatterns;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDayNames;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    uint8_t readOnly;
+    Il2CppString* decimalFormats;
+    Il2CppString* currencyFormats;
+    Il2CppString* percentFormats;
+    Il2CppString* digitPattern;
+    Il2CppString* zeroPattern;
+    int32_t currencyDecimalDigits;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppArray* currencyGroupSizes;
+    int32_t currencyNegativePattern;
+    int32_t currencyPositivePattern;
+    Il2CppString* currencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* negativeSign;
+    uint32_t numberDecimalDigits;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppArray* numberGroupSizes;
+    int32_t numberNegativePattern;
+    int32_t percentDecimalDigits;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppArray* percentGroupSizes;
+    int32_t percentNegativePattern;
+    int32_t percentPositivePattern;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* positiveSign;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t specific_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* displayname;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* icu_name;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppString* compareinfo;
+    const int32_t* calendar_data;
+    const void* text_info_data;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t lcid;
+    int32_t region_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    void* invalid_handle_value;
+    int refcount;
+    uint8_t owns_handle;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppString *str;
+    Il2CppString *cached_str;
+    int32_t max_capacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    Il2CppArray* data;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    int32_t options;
+    Il2CppArray *key;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    void *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+    uint64_t wait_event;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *socket;
+    intptr_t handle;
+    Il2CppObject *state;
+    Il2CppDelegate *callback;
+    Il2CppWaitHandle *wait_handle;
+    Il2CppException *delayedException;
+    Il2CppObject *ep;
+    Il2CppArray *buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject *accept_reuse_socket;
+    Il2CppArray *addresses;
+    int32_t port;
+    Il2CppObject *buffers;
+    uint8_t reusesocket;
+    Il2CppObject *acceptSocket;
+    int32_t total;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+    uint8_t blocking;
+    int32_t error;
+    int32_t operation;
+    Il2CppAsyncResult *ares;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct
+{
+    union
+    {
+        uint32_t ss32;
+        struct signscale
+        {
+            unsigned int reserved1 : 16;
+            unsigned int scale : 8;
+            unsigned int reserved2 : 7;
+            unsigned int sign : 1;
+        } signscale;
+    } u;
+    uint32_t hi32;
+    uint32_t lo32;
+    uint32_t mid32;
+} il2cpp_decimal_repr;

--- a/Il2CppInspector.Common/Outputs/Data/24.2-2019.2.8f1.i
+++ b/Il2CppInspector.Common/Outputs/Data/24.2-2019.2.8f1.i
@@ -1,0 +1,1634 @@
+typedef uint16_t Il2CppChar;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+static const Il2CppChar kIl2CppNewLine[] = { '\n', '\0' };
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+};
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+struct Il2CppManagedMemorySnapshot;
+typedef void (*Il2CppMethodPointer)();
+typedef uintptr_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *enum_info_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+    uint8_t tryDepth;
+} Il2CppSequencePoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass_0
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+typedef struct Il2CppClass_1
+{
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+typedef struct Il2CppClass {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexPair* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+void il2cpp_gc_wbarrier_set_field(Il2CppObject * obj, void **targetAddress, void *object);
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppEnumInfo
+{
+    Il2CppReflectionType *utype;
+    Il2CppArray *values;
+    Il2CppArray *names;
+    void* name_hash;
+} Il2CppEnumInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppArray *trace_ips;
+    Il2CppException *inner_ex;
+    Il2CppString *message;
+    Il2CppString *help_link;
+    Il2CppString *class_name;
+    Il2CppString *stack_trace;
+    Il2CppString *remote_stack_trace;
+    int32_t remote_stack_index;
+    il2cpp_hresult_t hresult;
+    Il2CppString *source;
+    Il2CppObject *_data;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+} Il2CppDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    uint8_t readOnly;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* TimeSeparator;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* FullDateTimePattern;
+    Il2CppString* RFC1123Pattern;
+    Il2CppString* SortableDateTimePattern;
+    Il2CppString* UniversalSortableDateTimePattern;
+    uint32_t FirstDayOfWeek;
+    Il2CppObject* Calendar;
+    uint32_t CalendarWeekRule;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* MonthDayPatterns;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDayNames;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    uint8_t readOnly;
+    Il2CppString* decimalFormats;
+    Il2CppString* currencyFormats;
+    Il2CppString* percentFormats;
+    Il2CppString* digitPattern;
+    Il2CppString* zeroPattern;
+    int32_t currencyDecimalDigits;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppArray* currencyGroupSizes;
+    int32_t currencyNegativePattern;
+    int32_t currencyPositivePattern;
+    Il2CppString* currencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* negativeSign;
+    uint32_t numberDecimalDigits;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppArray* numberGroupSizes;
+    int32_t numberNegativePattern;
+    int32_t percentDecimalDigits;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppArray* percentGroupSizes;
+    int32_t percentNegativePattern;
+    int32_t percentPositivePattern;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* positiveSign;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t specific_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* displayname;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* icu_name;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppString* compareinfo;
+    const int32_t* calendar_data;
+    const void* text_info_data;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t lcid;
+    int32_t region_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    void* invalid_handle_value;
+    int refcount;
+    uint8_t owns_handle;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppString *str;
+    Il2CppString *cached_str;
+    int32_t max_capacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    Il2CppArray* data;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    int32_t options;
+    Il2CppArray *key;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    void *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+    uint64_t wait_event;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *socket;
+    intptr_t handle;
+    Il2CppObject *state;
+    Il2CppDelegate *callback;
+    Il2CppWaitHandle *wait_handle;
+    Il2CppException *delayedException;
+    Il2CppObject *ep;
+    Il2CppArray *buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject *accept_reuse_socket;
+    Il2CppArray *addresses;
+    int32_t port;
+    Il2CppObject *buffers;
+    uint8_t reusesocket;
+    Il2CppObject *acceptSocket;
+    int32_t total;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+    uint8_t blocking;
+    int32_t error;
+    int32_t operation;
+    Il2CppAsyncResult *ares;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct
+{
+    union
+    {
+        uint32_t ss32;
+        struct signscale
+        {
+            unsigned int reserved1 : 16;
+            unsigned int scale : 8;
+            unsigned int reserved2 : 7;
+            unsigned int sign : 1;
+        } signscale;
+    } u;
+    uint32_t hi32;
+    uint32_t lo32;
+    uint32_t mid32;
+} il2cpp_decimal_repr;

--- a/Il2CppInspector.Common/Outputs/Data/24.2-2019.3.1f1.i
+++ b/Il2CppInspector.Common/Outputs/Data/24.2-2019.3.1f1.i
@@ -1,0 +1,1869 @@
+typedef uint16_t Il2CppChar;
+typedef void ( *SynchronizationContextCallback)(intptr_t arg);
+typedef uint32_t Il2CppMethodSlot;
+static const uint32_t kInvalidIl2CppMethodSlot = 65535;
+static const int ipv6AddressSize = 16;
+typedef int32_t il2cpp_hresult_t;
+static const Il2CppChar kIl2CppNewLine[] = { '\n', '\0' };
+typedef enum Il2CppTypeEnum
+{
+    IL2CPP_TYPE_END = 0x00,
+    IL2CPP_TYPE_VOID = 0x01,
+    IL2CPP_TYPE_BOOLEAN = 0x02,
+    IL2CPP_TYPE_CHAR = 0x03,
+    IL2CPP_TYPE_I1 = 0x04,
+    IL2CPP_TYPE_U1 = 0x05,
+    IL2CPP_TYPE_I2 = 0x06,
+    IL2CPP_TYPE_U2 = 0x07,
+    IL2CPP_TYPE_I4 = 0x08,
+    IL2CPP_TYPE_U4 = 0x09,
+    IL2CPP_TYPE_I8 = 0x0a,
+    IL2CPP_TYPE_U8 = 0x0b,
+    IL2CPP_TYPE_R4 = 0x0c,
+    IL2CPP_TYPE_R8 = 0x0d,
+    IL2CPP_TYPE_STRING = 0x0e,
+    IL2CPP_TYPE_PTR = 0x0f,
+    IL2CPP_TYPE_BYREF = 0x10,
+    IL2CPP_TYPE_VALUETYPE = 0x11,
+    IL2CPP_TYPE_CLASS = 0x12,
+    IL2CPP_TYPE_VAR = 0x13,
+    IL2CPP_TYPE_ARRAY = 0x14,
+    IL2CPP_TYPE_GENERICINST = 0x15,
+    IL2CPP_TYPE_TYPEDBYREF = 0x16,
+    IL2CPP_TYPE_I = 0x18,
+    IL2CPP_TYPE_U = 0x19,
+    IL2CPP_TYPE_FNPTR = 0x1b,
+    IL2CPP_TYPE_OBJECT = 0x1c,
+    IL2CPP_TYPE_SZARRAY = 0x1d,
+    IL2CPP_TYPE_MVAR = 0x1e,
+    IL2CPP_TYPE_CMOD_REQD = 0x1f,
+    IL2CPP_TYPE_CMOD_OPT = 0x20,
+    IL2CPP_TYPE_INTERNAL = 0x21,
+    IL2CPP_TYPE_MODIFIER = 0x40,
+    IL2CPP_TYPE_SENTINEL = 0x41,
+    IL2CPP_TYPE_PINNED = 0x45,
+    IL2CPP_TYPE_ENUM = 0x55
+} Il2CppTypeEnum;
+typedef int32_t TypeIndex;
+typedef int32_t TypeDefinitionIndex;
+typedef int32_t FieldIndex;
+typedef int32_t DefaultValueIndex;
+typedef int32_t DefaultValueDataIndex;
+typedef int32_t CustomAttributeIndex;
+typedef int32_t ParameterIndex;
+typedef int32_t MethodIndex;
+typedef int32_t GenericMethodIndex;
+typedef int32_t PropertyIndex;
+typedef int32_t EventIndex;
+typedef int32_t GenericContainerIndex;
+typedef int32_t GenericParameterIndex;
+typedef int16_t GenericParameterConstraintIndex;
+typedef int32_t NestedTypeIndex;
+typedef int32_t InterfacesIndex;
+typedef int32_t VTableIndex;
+typedef int32_t InterfaceOffsetIndex;
+typedef int32_t RGCTXIndex;
+typedef int32_t StringIndex;
+typedef int32_t StringLiteralIndex;
+typedef int32_t GenericInstIndex;
+typedef int32_t ImageIndex;
+typedef int32_t AssemblyIndex;
+typedef int32_t InteropDataIndex;
+static const TypeIndex kTypeIndexInvalid = -1;
+static const TypeDefinitionIndex kTypeDefinitionIndexInvalid = -1;
+static const DefaultValueDataIndex kDefaultValueIndexNull = -1;
+static const CustomAttributeIndex kCustomAttributeIndexInvalid = -1;
+static const EventIndex kEventIndexInvalid = -1;
+static const FieldIndex kFieldIndexInvalid = -1;
+static const MethodIndex kMethodIndexInvalid = -1;
+static const PropertyIndex kPropertyIndexInvalid = -1;
+static const GenericContainerIndex kGenericContainerIndexInvalid = -1;
+static const GenericParameterIndex kGenericParameterIndexInvalid = -1;
+static const RGCTXIndex kRGCTXIndexInvalid = -1;
+static const StringLiteralIndex kStringLiteralIndexInvalid = -1;
+static const InteropDataIndex kInteropDataIndexInvalid = -1;
+typedef uint32_t EncodedMethodIndex;
+enum Il2CppMetadataUsage
+{
+    kIl2CppMetadataUsageInvalid,
+    kIl2CppMetadataUsageTypeInfo,
+    kIl2CppMetadataUsageIl2CppType,
+    kIl2CppMetadataUsageMethodDef,
+    kIl2CppMetadataUsageFieldInfo,
+    kIl2CppMetadataUsageStringLiteral,
+    kIl2CppMetadataUsageMethodRef,
+};
+struct Il2CppImage;
+struct Il2CppType;
+struct Il2CppTypeDefinitionMetadata;
+typedef union Il2CppRGCTXDefinitionData
+{
+    int32_t rgctxDataDummy;
+    MethodIndex methodIndex;
+    TypeIndex typeIndex;
+} Il2CppRGCTXDefinitionData;
+typedef enum Il2CppRGCTXDataType
+{
+    IL2CPP_RGCTX_DATA_INVALID,
+    IL2CPP_RGCTX_DATA_TYPE,
+    IL2CPP_RGCTX_DATA_CLASS,
+    IL2CPP_RGCTX_DATA_METHOD,
+    IL2CPP_RGCTX_DATA_ARRAY,
+} Il2CppRGCTXDataType;
+typedef struct Il2CppRGCTXDefinition
+{
+    Il2CppRGCTXDataType type;
+    Il2CppRGCTXDefinitionData data;
+} Il2CppRGCTXDefinition;
+typedef struct Il2CppInterfaceOffsetPair
+{
+    TypeIndex interfaceTypeIndex;
+    int32_t offset;
+} Il2CppInterfaceOffsetPair;
+typedef struct Il2CppTypeDefinition
+{
+    StringIndex nameIndex;
+    StringIndex namespaceIndex;
+    TypeIndex byvalTypeIndex;
+    TypeIndex byrefTypeIndex;
+    TypeIndex declaringTypeIndex;
+    TypeIndex parentIndex;
+    TypeIndex elementTypeIndex;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t flags;
+    FieldIndex fieldStart;
+    MethodIndex methodStart;
+    EventIndex eventStart;
+    PropertyIndex propertyStart;
+    NestedTypeIndex nestedTypesStart;
+    InterfacesIndex interfacesStart;
+    VTableIndex vtableStart;
+    InterfacesIndex interfaceOffsetsStart;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint32_t bitfield;
+    uint32_t token;
+} Il2CppTypeDefinition;
+typedef struct Il2CppFieldDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    uint32_t token;
+} Il2CppFieldDefinition;
+typedef struct Il2CppFieldDefaultValue
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppFieldDefaultValue;
+typedef struct Il2CppFieldMarshaledSize
+{
+    FieldIndex fieldIndex;
+    TypeIndex typeIndex;
+    int32_t size;
+} Il2CppFieldMarshaledSize;
+typedef struct Il2CppFieldRef
+{
+    TypeIndex typeIndex;
+    FieldIndex fieldIndex;
+} Il2CppFieldRef;
+typedef struct Il2CppParameterDefinition
+{
+    StringIndex nameIndex;
+    uint32_t token;
+    TypeIndex typeIndex;
+} Il2CppParameterDefinition;
+typedef struct Il2CppParameterDefaultValue
+{
+    ParameterIndex parameterIndex;
+    TypeIndex typeIndex;
+    DefaultValueDataIndex dataIndex;
+} Il2CppParameterDefaultValue;
+typedef struct Il2CppMethodDefinition
+{
+    StringIndex nameIndex;
+    TypeDefinitionIndex declaringType;
+    TypeIndex returnType;
+    ParameterIndex parameterStart;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint16_t parameterCount;
+} Il2CppMethodDefinition;
+typedef struct Il2CppEventDefinition
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+    MethodIndex add;
+    MethodIndex remove;
+    MethodIndex raise;
+    uint32_t token;
+} Il2CppEventDefinition;
+typedef struct Il2CppPropertyDefinition
+{
+    StringIndex nameIndex;
+    MethodIndex get;
+    MethodIndex set;
+    uint32_t attrs;
+    uint32_t token;
+} Il2CppPropertyDefinition;
+typedef struct Il2CppMethodSpec
+{
+    MethodIndex methodDefinitionIndex;
+    GenericInstIndex classIndexIndex;
+    GenericInstIndex methodIndexIndex;
+} Il2CppMethodSpec;
+typedef struct Il2CppStringLiteral
+{
+    uint32_t length;
+    StringLiteralIndex dataIndex;
+} Il2CppStringLiteral;
+typedef struct
+{
+    MethodIndex methodIndex;
+    MethodIndex invokerIndex;
+} Il2CppGenericMethodIndices;
+typedef struct Il2CppGenericMethodFunctionsDefinitions
+{
+    GenericMethodIndex genericMethodIndex;
+    Il2CppGenericMethodIndices indices;
+} Il2CppGenericMethodFunctionsDefinitions;
+typedef struct Il2CppAssemblyNameDefinition
+{
+    StringIndex nameIndex;
+    StringIndex cultureIndex;
+    StringIndex hashValueIndex;
+    StringIndex publicKeyIndex;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyNameDefinition;
+typedef struct Il2CppImageDefinition
+{
+    StringIndex nameIndex;
+    AssemblyIndex assemblyIndex;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    MethodIndex entryPointIndex;
+    uint32_t token;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+} Il2CppImageDefinition;
+typedef struct Il2CppAssemblyDefinition
+{
+    ImageIndex imageIndex;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyNameDefinition aname;
+} Il2CppAssemblyDefinition;
+typedef struct Il2CppMetadataUsageList
+{
+    uint32_t start;
+    uint32_t count;
+} Il2CppMetadataUsageList;
+typedef struct Il2CppMetadataUsagePair
+{
+    uint32_t destinationIndex;
+    uint32_t encodedSourceIndex;
+} Il2CppMetadataUsagePair;
+typedef struct Il2CppCustomAttributeTypeRange
+{
+    uint32_t token;
+    int32_t start;
+    int32_t count;
+} Il2CppCustomAttributeTypeRange;
+typedef struct Il2CppRange
+{
+    int32_t start;
+    int32_t length;
+} Il2CppRange;
+typedef struct Il2CppWindowsRuntimeTypeNamePair
+{
+    StringIndex nameIndex;
+    TypeIndex typeIndex;
+} Il2CppWindowsRuntimeTypeNamePair;
+#pragma pack(push, p1,4)
+typedef struct Il2CppGlobalMetadataHeader
+{
+    int32_t sanity;
+    int32_t version;
+    int32_t stringLiteralOffset;
+    int32_t stringLiteralCount;
+    int32_t stringLiteralDataOffset;
+    int32_t stringLiteralDataCount;
+    int32_t stringOffset;
+    int32_t stringCount;
+    int32_t eventsOffset;
+    int32_t eventsCount;
+    int32_t propertiesOffset;
+    int32_t propertiesCount;
+    int32_t methodsOffset;
+    int32_t methodsCount;
+    int32_t parameterDefaultValuesOffset;
+    int32_t parameterDefaultValuesCount;
+    int32_t fieldDefaultValuesOffset;
+    int32_t fieldDefaultValuesCount;
+    int32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t fieldAndParameterDefaultValueDataCount;
+    int32_t fieldMarshaledSizesOffset;
+    int32_t fieldMarshaledSizesCount;
+    int32_t parametersOffset;
+    int32_t parametersCount;
+    int32_t fieldsOffset;
+    int32_t fieldsCount;
+    int32_t genericParametersOffset;
+    int32_t genericParametersCount;
+    int32_t genericParameterConstraintsOffset;
+    int32_t genericParameterConstraintsCount;
+    int32_t genericContainersOffset;
+    int32_t genericContainersCount;
+    int32_t nestedTypesOffset;
+    int32_t nestedTypesCount;
+    int32_t interfacesOffset;
+    int32_t interfacesCount;
+    int32_t vtableMethodsOffset;
+    int32_t vtableMethodsCount;
+    int32_t interfaceOffsetsOffset;
+    int32_t interfaceOffsetsCount;
+    int32_t typeDefinitionsOffset;
+    int32_t typeDefinitionsCount;
+    int32_t imagesOffset;
+    int32_t imagesCount;
+    int32_t assembliesOffset;
+    int32_t assembliesCount;
+    int32_t metadataUsageListsOffset;
+    int32_t metadataUsageListsCount;
+    int32_t metadataUsagePairsOffset;
+    int32_t metadataUsagePairsCount;
+    int32_t fieldRefsOffset;
+    int32_t fieldRefsCount;
+    int32_t referencedAssembliesOffset;
+    int32_t referencedAssembliesCount;
+    int32_t attributesInfoOffset;
+    int32_t attributesInfoCount;
+    int32_t attributeTypesOffset;
+    int32_t attributeTypesCount;
+    int32_t unresolvedVirtualCallParameterTypesOffset;
+    int32_t unresolvedVirtualCallParameterTypesCount;
+    int32_t unresolvedVirtualCallParameterRangesOffset;
+    int32_t unresolvedVirtualCallParameterRangesCount;
+    int32_t windowsRuntimeTypeNamesOffset;
+    int32_t windowsRuntimeTypeNamesSize;
+    int32_t exportedTypeDefinitionsOffset;
+    int32_t exportedTypeDefinitionsCount;
+} Il2CppGlobalMetadataHeader;
+#pragma pack(pop, p1)
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppType Il2CppType;
+typedef struct EventInfo EventInfo;
+typedef struct MethodInfo MethodInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppArray Il2CppArray;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppProfiler Il2CppProfiler;
+typedef struct Il2CppObject Il2CppObject;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppReflectionType Il2CppReflectionType;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppAsyncResult Il2CppAsyncResult;
+typedef struct Il2CppManagedMemorySnapshot Il2CppManagedMemorySnapshot;
+typedef struct Il2CppCustomAttrInfo Il2CppCustomAttrInfo;
+typedef enum
+{
+    IL2CPP_PROFILE_NONE = 0,
+    IL2CPP_PROFILE_APPDOMAIN_EVENTS = 1 << 0,
+    IL2CPP_PROFILE_ASSEMBLY_EVENTS = 1 << 1,
+    IL2CPP_PROFILE_MODULE_EVENTS = 1 << 2,
+    IL2CPP_PROFILE_CLASS_EVENTS = 1 << 3,
+    IL2CPP_PROFILE_JIT_COMPILATION = 1 << 4,
+    IL2CPP_PROFILE_INLINING = 1 << 5,
+    IL2CPP_PROFILE_EXCEPTIONS = 1 << 6,
+    IL2CPP_PROFILE_ALLOCATIONS = 1 << 7,
+    IL2CPP_PROFILE_GC = 1 << 8,
+    IL2CPP_PROFILE_THREADS = 1 << 9,
+    IL2CPP_PROFILE_REMOTING = 1 << 10,
+    IL2CPP_PROFILE_TRANSITIONS = 1 << 11,
+    IL2CPP_PROFILE_ENTER_LEAVE = 1 << 12,
+    IL2CPP_PROFILE_COVERAGE = 1 << 13,
+    IL2CPP_PROFILE_INS_COVERAGE = 1 << 14,
+    IL2CPP_PROFILE_STATISTICAL = 1 << 15,
+    IL2CPP_PROFILE_METHOD_EVENTS = 1 << 16,
+    IL2CPP_PROFILE_MONITOR_EVENTS = 1 << 17,
+    IL2CPP_PROFILE_IOMAP_EVENTS = 1 << 18,
+    IL2CPP_PROFILE_GC_MOVES = 1 << 19,
+    IL2CPP_PROFILE_FILEIO = 1 << 20
+} Il2CppProfileFlags;
+typedef enum
+{
+    IL2CPP_PROFILE_FILEIO_WRITE = 0,
+    IL2CPP_PROFILE_FILEIO_READ
+} Il2CppProfileFileIOKind;
+typedef enum
+{
+    IL2CPP_GC_EVENT_START,
+    IL2CPP_GC_EVENT_MARK_START,
+    IL2CPP_GC_EVENT_MARK_END,
+    IL2CPP_GC_EVENT_RECLAIM_START,
+    IL2CPP_GC_EVENT_RECLAIM_END,
+    IL2CPP_GC_EVENT_END,
+    IL2CPP_GC_EVENT_PRE_STOP_WORLD,
+    IL2CPP_GC_EVENT_POST_STOP_WORLD,
+    IL2CPP_GC_EVENT_PRE_START_WORLD,
+    IL2CPP_GC_EVENT_POST_START_WORLD
+} Il2CppGCEvent;
+typedef enum
+{
+    IL2CPP_STAT_NEW_OBJECT_COUNT,
+    IL2CPP_STAT_INITIALIZED_CLASS_COUNT,
+    IL2CPP_STAT_METHOD_COUNT,
+    IL2CPP_STAT_CLASS_STATIC_DATA_SIZE,
+    IL2CPP_STAT_GENERIC_INSTANCE_COUNT,
+    IL2CPP_STAT_GENERIC_CLASS_COUNT,
+    IL2CPP_STAT_INFLATED_METHOD_COUNT,
+    IL2CPP_STAT_INFLATED_TYPE_COUNT,
+} Il2CppStat;
+typedef enum
+{
+    IL2CPP_UNHANDLED_POLICY_LEGACY,
+    IL2CPP_UNHANDLED_POLICY_CURRENT
+} Il2CppRuntimeUnhandledExceptionPolicy;
+typedef struct Il2CppStackFrameInfo
+{
+    const MethodInfo *method;
+} Il2CppStackFrameInfo;
+typedef void(*Il2CppMethodPointer)();
+typedef struct Il2CppMethodDebugInfo
+{
+    Il2CppMethodPointer methodPointer;
+    int32_t code_size;
+    const char *file;
+} Il2CppMethodDebugInfo;
+typedef struct
+{
+    void* (*malloc_func)(size_t size);
+    void* (*aligned_malloc_func)(size_t size, size_t alignment);
+    void (*free_func)(void *ptr);
+    void (*aligned_free_func)(void *ptr);
+    void* (*calloc_func)(size_t nmemb, size_t size);
+    void* (*realloc_func)(void *ptr, size_t size);
+    void* (*aligned_realloc_func)(void *ptr, size_t size, size_t alignment);
+} Il2CppMemoryCallbacks;
+typedef struct
+{
+    const char *name;
+    void(*connect)(const char *address);
+    int(*wait_for_attach)(void);
+    void(*close1)(void);
+    void(*close2)(void);
+    int(*send)(void *buf, int len);
+    int(*recv)(void *buf, int len);
+} Il2CppDebuggerTransport;
+typedef char Il2CppNativeChar;
+typedef void (*il2cpp_register_object_callback)(Il2CppObject** arr, int size, void* userdata);
+typedef void (*il2cpp_WorldChangedCallback)();
+typedef void (*Il2CppFrameWalkFunc) (const Il2CppStackFrameInfo *info, void *user_data);
+typedef void (*Il2CppProfileFunc) (Il2CppProfiler* prof);
+typedef void (*Il2CppProfileMethodFunc) (Il2CppProfiler* prof, const MethodInfo *method);
+typedef void (*Il2CppProfileAllocFunc) (Il2CppProfiler* prof, Il2CppObject *obj, Il2CppClass *klass);
+typedef void (*Il2CppProfileGCFunc) (Il2CppProfiler* prof, Il2CppGCEvent event, int generation);
+typedef void (*Il2CppProfileGCResizeFunc) (Il2CppProfiler* prof, int64_t new_size);
+typedef void (*Il2CppProfileFileIOFunc) (Il2CppProfiler* prof, Il2CppProfileFileIOKind kind, int count);
+typedef void (*Il2CppProfileThreadFunc) (Il2CppProfiler *prof, unsigned long tid);
+typedef const Il2CppNativeChar* (*Il2CppSetFindPlugInCallback)(const Il2CppNativeChar*);
+typedef void (*Il2CppLogCallback)(const char*);
+typedef size_t(*Il2CppBacktraceFunc) (Il2CppMethodPointer* buffer, size_t maxSize);
+struct Il2CppManagedMemorySnapshot;
+typedef uintptr_t il2cpp_array_size_t;
+struct Il2CppClass;
+struct MethodInfo;
+struct Il2CppType;
+typedef struct Il2CppArrayType
+{
+    const Il2CppType* etype;
+    uint8_t rank;
+    uint8_t numsizes;
+    uint8_t numlobounds;
+    int *sizes;
+    int *lobounds;
+} Il2CppArrayType;
+typedef struct Il2CppGenericInst
+{
+    uint32_t type_argc;
+    const Il2CppType **type_argv;
+} Il2CppGenericInst;
+typedef struct Il2CppGenericContext
+{
+    const Il2CppGenericInst *class_inst;
+    const Il2CppGenericInst *method_inst;
+} Il2CppGenericContext;
+typedef struct Il2CppGenericParameter
+{
+    GenericContainerIndex ownerIndex;
+    StringIndex nameIndex;
+    GenericParameterConstraintIndex constraintsStart;
+    int16_t constraintsCount;
+    uint16_t num;
+    uint16_t flags;
+} Il2CppGenericParameter;
+typedef struct Il2CppGenericContainer
+{
+    int32_t ownerIndex;
+    int32_t type_argc;
+    int32_t is_method;
+    GenericParameterIndex genericParameterStart;
+} Il2CppGenericContainer;
+typedef struct Il2CppGenericClass
+{
+    TypeDefinitionIndex typeDefinitionIndex;
+    Il2CppGenericContext context;
+    Il2CppClass *cached_class;
+} Il2CppGenericClass;
+typedef struct Il2CppGenericMethod
+{
+    const MethodInfo* methodDefinition;
+    Il2CppGenericContext context;
+} Il2CppGenericMethod;
+typedef struct Il2CppType
+{
+    union
+    {
+        void* dummy;
+        TypeDefinitionIndex klassIndex;
+        const Il2CppType *type;
+        Il2CppArrayType *array;
+        GenericParameterIndex genericParameterIndex;
+        Il2CppGenericClass *generic_class;
+    } data;
+    unsigned int attrs : 16;
+    Il2CppTypeEnum type : 8;
+    unsigned int num_mods : 6;
+    unsigned int byref : 1;
+    unsigned int pinned : 1;
+} Il2CppType;
+typedef struct Il2CppClass Il2CppClass;
+typedef struct Il2CppGuid Il2CppGuid;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppAppDomain Il2CppAppDomain;
+typedef struct Il2CppAppDomainSetup Il2CppAppDomainSetup;
+typedef struct Il2CppDelegate Il2CppDelegate;
+typedef struct Il2CppAppContext Il2CppAppContext;
+typedef struct Il2CppNameToTypeDefinitionIndexHashTable Il2CppNameToTypeDefinitionIndexHashTable;
+typedef struct Il2CppCodeGenModule Il2CppCodeGenModule;
+typedef struct VirtualInvokeData
+{
+    Il2CppMethodPointer methodPtr;
+    const MethodInfo* method;
+} VirtualInvokeData;
+typedef enum Il2CppTypeNameFormat
+{
+    IL2CPP_TYPE_NAME_FORMAT_IL,
+    IL2CPP_TYPE_NAME_FORMAT_REFLECTION,
+    IL2CPP_TYPE_NAME_FORMAT_FULL_NAME,
+    IL2CPP_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED
+} Il2CppTypeNameFormat;
+typedef struct Il2CppDefaults
+{
+    Il2CppImage *corlib;
+    Il2CppClass *object_class;
+    Il2CppClass *byte_class;
+    Il2CppClass *void_class;
+    Il2CppClass *boolean_class;
+    Il2CppClass *sbyte_class;
+    Il2CppClass *int16_class;
+    Il2CppClass *uint16_class;
+    Il2CppClass *int32_class;
+    Il2CppClass *uint32_class;
+    Il2CppClass *int_class;
+    Il2CppClass *uint_class;
+    Il2CppClass *int64_class;
+    Il2CppClass *uint64_class;
+    Il2CppClass *single_class;
+    Il2CppClass *double_class;
+    Il2CppClass *char_class;
+    Il2CppClass *string_class;
+    Il2CppClass *enum_class;
+    Il2CppClass *array_class;
+    Il2CppClass *delegate_class;
+    Il2CppClass *multicastdelegate_class;
+    Il2CppClass *asyncresult_class;
+    Il2CppClass *manualresetevent_class;
+    Il2CppClass *typehandle_class;
+    Il2CppClass *fieldhandle_class;
+    Il2CppClass *methodhandle_class;
+    Il2CppClass *systemtype_class;
+    Il2CppClass *monotype_class;
+    Il2CppClass *exception_class;
+    Il2CppClass *threadabortexception_class;
+    Il2CppClass *thread_class;
+    Il2CppClass *internal_thread_class;
+    Il2CppClass *appdomain_class;
+    Il2CppClass *appdomain_setup_class;
+    Il2CppClass *field_info_class;
+    Il2CppClass *method_info_class;
+    Il2CppClass *property_info_class;
+    Il2CppClass *event_info_class;
+    Il2CppClass *mono_event_info_class;
+    Il2CppClass *stringbuilder_class;
+    Il2CppClass *stack_frame_class;
+    Il2CppClass *stack_trace_class;
+    Il2CppClass *marshal_class;
+    Il2CppClass *typed_reference_class;
+    Il2CppClass *marshalbyrefobject_class;
+    Il2CppClass *generic_ilist_class;
+    Il2CppClass *generic_icollection_class;
+    Il2CppClass *generic_ienumerable_class;
+    Il2CppClass *generic_ireadonlylist_class;
+    Il2CppClass *generic_ireadonlycollection_class;
+    Il2CppClass *runtimetype_class;
+    Il2CppClass *generic_nullable_class;
+    Il2CppClass *il2cpp_com_object_class;
+    Il2CppClass *attribute_class;
+    Il2CppClass *customattribute_data_class;
+    Il2CppClass *version;
+    Il2CppClass *culture_info;
+    Il2CppClass *async_call_class;
+    Il2CppClass *assembly_class;
+    Il2CppClass *mono_assembly_class;
+    Il2CppClass *assembly_name_class;
+    Il2CppClass *mono_field_class;
+    Il2CppClass *mono_method_class;
+    Il2CppClass *mono_method_info_class;
+    Il2CppClass *mono_property_info_class;
+    Il2CppClass *parameter_info_class;
+    Il2CppClass *mono_parameter_info_class;
+    Il2CppClass *module_class;
+    Il2CppClass *pointer_class;
+    Il2CppClass *system_exception_class;
+    Il2CppClass *argument_exception_class;
+    Il2CppClass *wait_handle_class;
+    Il2CppClass *safe_handle_class;
+    Il2CppClass *sort_key_class;
+    Il2CppClass *dbnull_class;
+    Il2CppClass *error_wrapper_class;
+    Il2CppClass *missing_class;
+    Il2CppClass *value_type_class;
+    Il2CppClass *threadpool_wait_callback_class;
+    MethodInfo *threadpool_perform_wait_callback_method;
+    Il2CppClass *mono_method_message_class;
+    Il2CppClass* ireference_class;
+    Il2CppClass* ireferencearray_class;
+    Il2CppClass* ikey_value_pair_class;
+    Il2CppClass* key_value_pair_class;
+    Il2CppClass* windows_foundation_uri_class;
+    Il2CppClass* windows_foundation_iuri_runtime_class_class;
+    Il2CppClass* system_uri_class;
+    Il2CppClass* system_guid_class;
+    Il2CppClass* sbyte_shared_enum;
+    Il2CppClass* int16_shared_enum;
+    Il2CppClass* int32_shared_enum;
+    Il2CppClass* int64_shared_enum;
+    Il2CppClass* byte_shared_enum;
+    Il2CppClass* uint16_shared_enum;
+    Il2CppClass* uint32_shared_enum;
+    Il2CppClass* uint64_shared_enum;
+} Il2CppDefaults;
+extern Il2CppDefaults il2cpp_defaults;
+struct Il2CppClass;
+struct MethodInfo;
+struct FieldInfo;
+struct Il2CppObject;
+struct MemberInfo;
+typedef struct CustomAttributesCache
+{
+    int count;
+    Il2CppObject** attributes;
+} CustomAttributesCache;
+typedef void (*CustomAttributesCacheGenerator)(CustomAttributesCache*);
+typedef struct FieldInfo
+{
+    const char* name;
+    const Il2CppType* type;
+    Il2CppClass *parent;
+    int32_t offset;
+    uint32_t token;
+} FieldInfo;
+typedef struct PropertyInfo
+{
+    Il2CppClass *parent;
+    const char *name;
+    const MethodInfo *get;
+    const MethodInfo *set;
+    uint32_t attrs;
+    uint32_t token;
+} PropertyInfo;
+typedef struct EventInfo
+{
+    const char* name;
+    const Il2CppType* eventType;
+    Il2CppClass* parent;
+    const MethodInfo* add;
+    const MethodInfo* remove;
+    const MethodInfo* raise;
+    uint32_t token;
+} EventInfo;
+typedef struct ParameterInfo
+{
+    const char* name;
+    int32_t position;
+    uint32_t token;
+    const Il2CppType* parameter_type;
+} ParameterInfo;
+typedef void* (*InvokerMethod)(Il2CppMethodPointer, const MethodInfo*, void*, void**);
+typedef enum MethodVariableKind
+{
+    kMethodVariableKind_This,
+    kMethodVariableKind_Parameter,
+    kMethodVariableKind_LocalVariable
+} MethodVariableKind;
+typedef enum SequencePointKind
+{
+    kSequencePointKind_Normal,
+    kSequencePointKind_StepOut
+} SequencePointKind;
+typedef struct Il2CppMethodExecutionContextInfo
+{
+    TypeIndex typeIndex;
+    int32_t nameIndex;
+    int32_t scopeIndex;
+} Il2CppMethodExecutionContextInfo;
+typedef struct Il2CppMethodExecutionContextInfoIndex
+{
+    int32_t startIndex;
+    int32_t count;
+} Il2CppMethodExecutionContextInfoIndex;
+typedef struct Il2CppMethodScope
+{
+    int32_t startOffset;
+    int32_t endOffset;
+} Il2CppMethodScope;
+typedef struct Il2CppMethodHeaderInfo
+{
+    int32_t code_size;
+    int32_t startScope;
+    int32_t numScopes;
+} Il2CppMethodHeaderInfo;
+typedef struct Il2CppSequencePointSourceFile
+{
+    const char *file;
+    uint8_t hash[16];
+} Il2CppSequencePointSourceFile;
+typedef struct Il2CppTypeSourceFilePair
+{
+    TypeDefinitionIndex klassIndex;
+    int32_t sourceFileIndex;
+} Il2CppTypeSourceFilePair;
+typedef struct Il2CppSequencePoint
+{
+    MethodIndex methodDefinitionIndex;
+    int32_t sourceFileIndex;
+    int32_t lineStart, lineEnd;
+    int32_t columnStart, columnEnd;
+    int32_t ilOffset;
+    SequencePointKind kind;
+    int32_t isActive;
+    int32_t id;
+} Il2CppSequencePoint;
+typedef struct Il2CppCatchPoint
+{
+    MethodIndex methodDefinitionIndex;
+    TypeIndex catchTypeIndex;
+    int32_t ilOffset;
+    int8_t tryId;
+    int8_t parentTryId;
+} Il2CppCatchPoint;
+typedef struct Il2CppDebuggerMetadataRegistration
+{
+    Il2CppMethodExecutionContextInfo* methodExecutionContextInfos;
+    Il2CppMethodExecutionContextInfoIndex* methodExecutionContextInfoIndexes;
+    Il2CppMethodScope* methodScopes;
+    Il2CppMethodHeaderInfo* methodHeaderInfos;
+    Il2CppSequencePointSourceFile* sequencePointSourceFiles;
+    int32_t numSequencePoints;
+    Il2CppSequencePoint* sequencePoints;
+    int32_t numCatchPoints;
+    Il2CppCatchPoint* catchPoints;
+    int32_t numTypeSourceFileEntries;
+    Il2CppTypeSourceFilePair* typeSourceFiles;
+    const char** methodExecutionContextInfoStrings;
+} Il2CppDebuggerMetadataRegistration;
+typedef union Il2CppRGCTXData
+{
+    void* rgctxDataDummy;
+    const MethodInfo* method;
+    const Il2CppType* type;
+    Il2CppClass* klass;
+} Il2CppRGCTXData;
+typedef struct MethodInfo
+{
+    Il2CppMethodPointer methodPointer;
+    InvokerMethod invoker_method;
+    const char* name;
+    Il2CppClass *klass;
+    const Il2CppType *return_type;
+    const ParameterInfo* parameters;
+    union
+    {
+        const Il2CppRGCTXData* rgctx_data;
+        const Il2CppMethodDefinition* methodDefinition;
+    };
+    union
+    {
+        const Il2CppGenericMethod* genericMethod;
+        const Il2CppGenericContainer* genericContainer;
+    };
+    uint32_t token;
+    uint16_t flags;
+    uint16_t iflags;
+    uint16_t slot;
+    uint8_t parameters_count;
+    uint8_t is_generic : 1;
+    uint8_t is_inflated : 1;
+    uint8_t wrapper_type : 1;
+    uint8_t is_marshaled_from_native : 1;
+} MethodInfo;
+typedef struct Il2CppRuntimeInterfaceOffsetPair
+{
+    Il2CppClass* interfaceType;
+    int32_t offset;
+} Il2CppRuntimeInterfaceOffsetPair;
+typedef enum Il2CppCallConvention
+{
+    IL2CPP_CALL_DEFAULT,
+    IL2CPP_CALL_C,
+    IL2CPP_CALL_STDCALL,
+    IL2CPP_CALL_THISCALL,
+    IL2CPP_CALL_FASTCALL,
+    IL2CPP_CALL_VARARG
+} Il2CppCallConvention;
+typedef enum Il2CppCharSet
+{
+    CHARSET_ANSI,
+    CHARSET_UNICODE,
+    CHARSET_NOT_SPECIFIED
+} Il2CppCharSet;
+typedef void (*PInvokeMarshalToNativeFunc)(void* managedStructure, void* marshaledStructure);
+typedef void (*PInvokeMarshalFromNativeFunc)(void* marshaledStructure, void* managedStructure);
+typedef void (*PInvokeMarshalCleanupFunc)(void* marshaledStructure);
+typedef struct Il2CppIUnknown* (*CreateCCWFunc)(Il2CppObject* obj);
+typedef struct Il2CppInteropData
+{
+    Il2CppMethodPointer delegatePInvokeWrapperFunction;
+    PInvokeMarshalToNativeFunc pinvokeMarshalToNativeFunction;
+    PInvokeMarshalFromNativeFunc pinvokeMarshalFromNativeFunction;
+    PInvokeMarshalCleanupFunc pinvokeMarshalCleanupFunction;
+    CreateCCWFunc createCCWFunction;
+    const Il2CppGuid* guid;
+    const Il2CppType* type;
+} Il2CppInteropData;
+typedef struct Il2CppClass_0
+{
+    const Il2CppImage* image;
+    void* gc_desc;
+    const char* name;
+    const char* namespaze;
+    Il2CppType byval_arg;
+    Il2CppType this_arg;
+    Il2CppClass* element_class;
+    Il2CppClass* castClass;
+    Il2CppClass* declaringType;
+    Il2CppClass* parent;
+    Il2CppGenericClass *generic_class;
+    const Il2CppTypeDefinition* typeDefinition;
+    const Il2CppInteropData* interopData;
+    Il2CppClass* klass;
+    FieldInfo* fields;
+    const EventInfo* events;
+    const PropertyInfo* properties;
+    const MethodInfo** methods;
+    Il2CppClass** nestedTypes;
+    Il2CppClass** implementedInterfaces;
+} Il2CppClass_0;
+typedef struct Il2CppClass_1
+{
+    Il2CppClass** typeHierarchy;
+    void *unity_user_data;
+    uint32_t initializationExceptionGCHandle;
+    uint32_t cctor_started;
+    uint32_t cctor_finished;
+    size_t cctor_thread;
+    GenericContainerIndex genericContainerIndex;
+    uint32_t instance_size;
+    uint32_t actualSize;
+    uint32_t element_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+    int32_t thread_static_fields_offset;
+    uint32_t flags;
+    uint32_t token;
+    uint16_t method_count;
+    uint16_t property_count;
+    uint16_t field_count;
+    uint16_t event_count;
+    uint16_t nested_type_count;
+    uint16_t vtable_count;
+    uint16_t interfaces_count;
+    uint16_t interface_offsets_count;
+    uint8_t typeHierarchyDepth;
+    uint8_t genericRecursionDepth;
+    uint8_t rank;
+    uint8_t minimumAlignment;
+    uint8_t naturalAligment;
+    uint8_t packingSize;
+    uint8_t initialized_and_no_error : 1;
+    uint8_t valuetype : 1;
+    uint8_t initialized : 1;
+    uint8_t enumtype : 1;
+    uint8_t is_generic : 1;
+    uint8_t has_references : 1;
+    uint8_t init_pending : 1;
+    uint8_t size_inited : 1;
+    uint8_t has_finalize : 1;
+    uint8_t has_cctor : 1;
+    uint8_t is_blittable : 1;
+    uint8_t is_import_or_windows_runtime : 1;
+    uint8_t is_vtable_initialized : 1;
+    uint8_t has_initialization_error : 1;
+} Il2CppClass_1;
+typedef struct Il2CppClass {
+    struct Il2CppClass_0 _0;
+    Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets;
+    void* static_fields;
+    const Il2CppRGCTXData* rgctx_data;
+    struct Il2CppClass_1 _1;
+    VirtualInvokeData vtable[32];
+} Il2CppClass;
+typedef struct Il2CppTypeDefinitionSizes
+{
+    uint32_t instance_size;
+    int32_t native_size;
+    uint32_t static_fields_size;
+    uint32_t thread_static_fields_size;
+} Il2CppTypeDefinitionSizes;
+typedef struct Il2CppDomain
+{
+    Il2CppAppDomain* domain;
+    Il2CppAppDomainSetup* setup;
+    Il2CppAppContext* default_context;
+    const char* friendly_name;
+    uint32_t domain_id;
+    volatile int threadpool_jobs;
+    void* agent_info;
+} Il2CppDomain;
+typedef struct Il2CppAssemblyName
+{
+    const char* name;
+    const char* culture;
+    const char* hash_value;
+    const char* public_key;
+    uint32_t hash_alg;
+    int32_t hash_len;
+    uint32_t flags;
+    int32_t major;
+    int32_t minor;
+    int32_t build;
+    int32_t revision;
+    uint8_t public_key_token[8];
+} Il2CppAssemblyName;
+typedef struct Il2CppImage
+{
+    const char* name;
+    const char *nameNoExt;
+    Il2CppAssembly* assembly;
+    TypeDefinitionIndex typeStart;
+    uint32_t typeCount;
+    TypeDefinitionIndex exportedTypeStart;
+    uint32_t exportedTypeCount;
+    CustomAttributeIndex customAttributeStart;
+    uint32_t customAttributeCount;
+    MethodIndex entryPointIndex;
+    Il2CppNameToTypeDefinitionIndexHashTable * nameToClassHashTable;
+    const Il2CppCodeGenModule* codeGenModule;
+    uint32_t token;
+    uint8_t dynamic;
+} Il2CppImage;
+typedef struct Il2CppAssembly
+{
+    Il2CppImage* image;
+    uint32_t token;
+    int32_t referencedAssemblyStart;
+    int32_t referencedAssemblyCount;
+    Il2CppAssemblyName aname;
+} Il2CppAssembly;
+typedef struct Il2CppCodeGenOptions
+{
+    uint8_t enablePrimitiveValueTypeGenericSharing;
+} Il2CppCodeGenOptions;
+typedef struct Il2CppTokenIndexPair
+{
+    uint32_t token;
+    int32_t index;
+} Il2CppTokenIndexPair;
+typedef struct Il2CppTokenRangePair
+{
+    uint32_t token;
+    Il2CppRange range;
+} Il2CppTokenRangePair;
+typedef struct Il2CppTokenIndexMethodTuple
+{
+    uint32_t token;
+    int32_t index;
+    void** method;
+    uint32_t genericMethodIndex;
+} Il2CppTokenIndexMethodTuple;
+typedef struct Il2CppCodeGenModule
+{
+    const char* moduleName;
+    const uint32_t methodPointerCount;
+    const Il2CppMethodPointer* methodPointers;
+    const int32_t* invokerIndices;
+    const uint32_t reversePInvokeWrapperCount;
+    const Il2CppTokenIndexMethodTuple* reversePInvokeWrapperIndices;
+    const uint32_t rgctxRangesCount;
+    const Il2CppTokenRangePair* rgctxRanges;
+    const uint32_t rgctxsCount;
+    const Il2CppRGCTXDefinition* rgctxs;
+    const Il2CppDebuggerMetadataRegistration *debuggerMetadata;
+} Il2CppCodeGenModule;
+typedef struct Il2CppCodeRegistration
+{
+    uint32_t reversePInvokeWrapperCount;
+    const Il2CppMethodPointer* reversePInvokeWrappers;
+    uint32_t genericMethodPointersCount;
+    const Il2CppMethodPointer* genericMethodPointers;
+    uint32_t invokerPointersCount;
+    const InvokerMethod* invokerPointers;
+    CustomAttributeIndex customAttributeCount;
+    const CustomAttributesCacheGenerator* customAttributeGenerators;
+    uint32_t unresolvedVirtualCallCount;
+    const Il2CppMethodPointer* unresolvedVirtualCallPointers;
+    uint32_t interopDataCount;
+    Il2CppInteropData* interopData;
+    uint32_t codeGenModulesCount;
+    const Il2CppCodeGenModule** codeGenModules;
+} Il2CppCodeRegistration;
+typedef struct Il2CppMetadataRegistration
+{
+    int32_t genericClassesCount;
+    Il2CppGenericClass* const * genericClasses;
+    int32_t genericInstsCount;
+    const Il2CppGenericInst* const * genericInsts;
+    int32_t genericMethodTableCount;
+    const Il2CppGenericMethodFunctionsDefinitions* genericMethodTable;
+    int32_t typesCount;
+    const Il2CppType* const * types;
+    int32_t methodSpecsCount;
+    const Il2CppMethodSpec* methodSpecs;
+    FieldIndex fieldOffsetsCount;
+    const int32_t** fieldOffsets;
+    TypeDefinitionIndex typeDefinitionsSizesCount;
+    const Il2CppTypeDefinitionSizes** typeDefinitionsSizes;
+    const size_t metadataUsagesCount;
+    void** const* metadataUsages;
+} Il2CppMetadataRegistration;
+typedef struct Il2CppPerfCounters
+{
+    uint32_t jit_methods;
+    uint32_t jit_bytes;
+    uint32_t jit_time;
+    uint32_t jit_failures;
+    uint32_t exceptions_thrown;
+    uint32_t exceptions_filters;
+    uint32_t exceptions_finallys;
+    uint32_t exceptions_depth;
+    uint32_t aspnet_requests_queued;
+    uint32_t aspnet_requests;
+    uint32_t gc_collections0;
+    uint32_t gc_collections1;
+    uint32_t gc_collections2;
+    uint32_t gc_promotions0;
+    uint32_t gc_promotions1;
+    uint32_t gc_promotion_finalizers;
+    uint32_t gc_gen0size;
+    uint32_t gc_gen1size;
+    uint32_t gc_gen2size;
+    uint32_t gc_lossize;
+    uint32_t gc_fin_survivors;
+    uint32_t gc_num_handles;
+    uint32_t gc_allocated;
+    uint32_t gc_induced;
+    uint32_t gc_time;
+    uint32_t gc_total_bytes;
+    uint32_t gc_committed_bytes;
+    uint32_t gc_reserved_bytes;
+    uint32_t gc_num_pinned;
+    uint32_t gc_sync_blocks;
+    uint32_t remoting_calls;
+    uint32_t remoting_channels;
+    uint32_t remoting_proxies;
+    uint32_t remoting_classes;
+    uint32_t remoting_objects;
+    uint32_t remoting_contexts;
+    uint32_t loader_classes;
+    uint32_t loader_total_classes;
+    uint32_t loader_appdomains;
+    uint32_t loader_total_appdomains;
+    uint32_t loader_assemblies;
+    uint32_t loader_total_assemblies;
+    uint32_t loader_failures;
+    uint32_t loader_bytes;
+    uint32_t loader_appdomains_uloaded;
+    uint32_t thread_contentions;
+    uint32_t thread_queue_len;
+    uint32_t thread_queue_max;
+    uint32_t thread_num_logical;
+    uint32_t thread_num_physical;
+    uint32_t thread_cur_recognized;
+    uint32_t thread_num_recognized;
+    uint32_t interop_num_ccw;
+    uint32_t interop_num_stubs;
+    uint32_t interop_num_marshals;
+    uint32_t security_num_checks;
+    uint32_t security_num_link_checks;
+    uint32_t security_time;
+    uint32_t security_depth;
+    uint32_t unused;
+    uint64_t threadpool_workitems;
+    uint64_t threadpool_ioworkitems;
+    unsigned int threadpool_threads;
+    unsigned int threadpool_iothreads;
+} Il2CppPerfCounters;
+void il2cpp_gc_wbarrier_set_field(Il2CppObject * obj, void **targetAddress, void *object);
+typedef struct Il2CppClass Il2CppClass;
+typedef struct MethodInfo MethodInfo;
+typedef struct PropertyInfo PropertyInfo;
+typedef struct FieldInfo FieldInfo;
+typedef struct EventInfo EventInfo;
+typedef struct Il2CppType Il2CppType;
+typedef struct Il2CppAssembly Il2CppAssembly;
+typedef struct Il2CppException Il2CppException;
+typedef struct Il2CppImage Il2CppImage;
+typedef struct Il2CppDomain Il2CppDomain;
+typedef struct Il2CppString Il2CppString;
+typedef struct Il2CppReflectionMethod Il2CppReflectionMethod;
+typedef struct Il2CppAsyncCall Il2CppAsyncCall;
+typedef struct Il2CppIUnknown Il2CppIUnknown;
+typedef struct Il2CppWaitHandle Il2CppWaitHandle;
+typedef struct MonitorData MonitorData;
+typedef struct Il2CppReflectionAssembly Il2CppReflectionAssembly;
+typedef Il2CppClass Il2CppVTable;
+typedef struct Il2CppObject
+{
+    union
+    {
+        Il2CppClass *klass;
+        Il2CppVTable *vtable;
+    };
+    MonitorData *monitor;
+} Il2CppObject;
+typedef int32_t il2cpp_array_lower_bound_t;
+typedef struct Il2CppArrayBounds
+{
+    il2cpp_array_size_t length;
+    il2cpp_array_lower_bound_t lower_bound;
+} Il2CppArrayBounds;
+typedef struct Il2CppArray
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+} Il2CppArray;
+typedef struct Il2CppArraySize
+{
+    Il2CppObject obj;
+    Il2CppArrayBounds *bounds;
+    il2cpp_array_size_t max_length;
+    __attribute__((aligned(8))) void* vector[32];
+} Il2CppArraySize;
+typedef struct Il2CppString
+{
+    Il2CppObject object;
+    int32_t length;
+    Il2CppChar chars[32];
+} Il2CppString;
+typedef struct Il2CppReflectionType
+{
+    Il2CppObject object;
+    const Il2CppType *type;
+} Il2CppReflectionType;
+typedef struct Il2CppReflectionRuntimeType
+{
+    Il2CppReflectionType type;
+    Il2CppObject *type_info;
+    Il2CppObject* genericCache;
+    Il2CppObject* serializationCtor;
+} Il2CppReflectionRuntimeType;
+typedef struct Il2CppReflectionMonoType
+{
+    Il2CppReflectionRuntimeType type;
+} Il2CppReflectionMonoType;
+typedef struct Il2CppReflectionEvent
+{
+    Il2CppObject object;
+    Il2CppObject *cached_add_event;
+} Il2CppReflectionEvent;
+typedef struct Il2CppReflectionMonoEvent
+{
+    Il2CppReflectionEvent event;
+    Il2CppReflectionType* reflectedType;
+    const EventInfo* eventInfo;
+} Il2CppReflectionMonoEvent;
+typedef struct Il2CppReflectionMonoEventInfo
+{
+    Il2CppReflectionType* declaringType;
+    Il2CppReflectionType* reflectedType;
+    Il2CppString* name;
+    Il2CppReflectionMethod* addMethod;
+    Il2CppReflectionMethod* removeMethod;
+    Il2CppReflectionMethod* raiseMethod;
+    uint32_t eventAttributes;
+    Il2CppArray* otherMethods;
+} Il2CppReflectionMonoEventInfo;
+typedef struct Il2CppReflectionField
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    FieldInfo *field;
+    Il2CppString *name;
+    Il2CppReflectionType *type;
+    uint32_t attrs;
+} Il2CppReflectionField;
+typedef struct Il2CppReflectionProperty
+{
+    Il2CppObject object;
+    Il2CppClass *klass;
+    const PropertyInfo *property;
+} Il2CppReflectionProperty;
+typedef struct Il2CppReflectionMethod
+{
+    Il2CppObject object;
+    const MethodInfo *method;
+    Il2CppString *name;
+    Il2CppReflectionType *reftype;
+} Il2CppReflectionMethod;
+typedef struct Il2CppReflectionGenericMethod
+{
+    Il2CppReflectionMethod base;
+} Il2CppReflectionGenericMethod;
+typedef struct Il2CppMethodInfo
+{
+    Il2CppReflectionType *parent;
+    Il2CppReflectionType *ret;
+    uint32_t attrs;
+    uint32_t implattrs;
+    uint32_t callconv;
+} Il2CppMethodInfo;
+typedef struct Il2CppPropertyInfo
+{
+    Il2CppReflectionType* parent;
+    Il2CppReflectionType* declaringType;
+    Il2CppString *name;
+    Il2CppReflectionMethod *get;
+    Il2CppReflectionMethod *set;
+    uint32_t attrs;
+} Il2CppPropertyInfo;
+typedef struct Il2CppReflectionParameter
+{
+    Il2CppObject object;
+    Il2CppReflectionType *ClassImpl;
+    Il2CppObject *DefaultValueImpl;
+    Il2CppObject *MemberImpl;
+    Il2CppString *NameImpl;
+    int32_t PositionImpl;
+    uint32_t AttrsImpl;
+    Il2CppObject *MarshalAsImpl;
+} Il2CppReflectionParameter;
+typedef struct Il2CppReflectionModule
+{
+    Il2CppObject obj;
+    const Il2CppImage* image;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* fqname;
+    Il2CppString* name;
+    Il2CppString* scopename;
+    uint8_t is_resource;
+    uint32_t token;
+} Il2CppReflectionModule;
+typedef struct Il2CppReflectionAssemblyName
+{
+    Il2CppObject obj;
+    Il2CppString *name;
+    Il2CppString *codebase;
+    int32_t major, minor, build, revision;
+    Il2CppObject *cultureInfo;
+    uint32_t flags;
+    uint32_t hashalg;
+    Il2CppObject *keypair;
+    Il2CppArray *publicKey;
+    Il2CppArray *keyToken;
+    uint32_t versioncompat;
+    Il2CppObject *version;
+    uint32_t processor_architecture;
+    uint32_t contentType;
+} Il2CppReflectionAssemblyName;
+typedef struct Il2CppReflectionAssembly
+{
+    Il2CppObject object;
+    const Il2CppAssembly *assembly;
+    Il2CppObject *resolve_event_holder;
+    Il2CppObject *evidence;
+    Il2CppObject *minimum;
+    Il2CppObject *optional;
+    Il2CppObject *refuse;
+    Il2CppObject *granted;
+    Il2CppObject *denied;
+    uint8_t from_byte_array;
+    Il2CppString *name;
+} Il2CppReflectionAssembly;
+typedef struct Il2CppReflectionMarshal
+{
+    Il2CppObject object;
+    int32_t count;
+    int32_t type;
+    int32_t eltype;
+    Il2CppString* guid;
+    Il2CppString* mcookie;
+    Il2CppString* marshaltype;
+    Il2CppObject* marshaltyperef;
+    int32_t param_num;
+    uint8_t has_size;
+} Il2CppReflectionMarshal;
+typedef struct Il2CppReflectionPointer
+{
+    Il2CppObject object;
+    void* data;
+    Il2CppReflectionType* type;
+} Il2CppReflectionPointer;
+typedef struct Il2CppInternalThread
+{
+    Il2CppObject obj;
+    int lock_thread_id;
+    void* handle;
+    void* native_handle;
+    Il2CppArray* cached_culture_info;
+    Il2CppChar* name;
+    int name_len;
+    uint32_t state;
+    Il2CppObject* abort_exc;
+    int abort_state_handle;
+    uint64_t tid;
+    intptr_t debugger_thread;
+    void** static_data;
+    void* runtime_thread_info;
+    Il2CppObject* current_appcontext;
+    Il2CppObject* root_domain_thread;
+    Il2CppArray* _serialized_principal;
+    int _serialized_principal_version;
+    void* appdomain_refs;
+    int32_t interruption_requested;
+    void* synch_cs;
+    uint8_t threadpool_thread;
+    uint8_t thread_interrupt_requested;
+    int stack_size;
+    uint8_t apartment_state;
+    int critical_region_level;
+    int managed_id;
+    uint32_t small_id;
+    void* manage_callback;
+    void* interrupt_on_stop;
+    intptr_t flags;
+    void* thread_pinning_ref;
+    void* abort_protected_block_count;
+    int32_t priority;
+    void* owned_mutexes;
+    void * suspended;
+    int32_t self_suspended;
+    size_t thread_state;
+    size_t unused2;
+    void* last;
+} Il2CppInternalThread;
+typedef struct Il2CppIOSelectorJob
+{
+    Il2CppObject object;
+    int32_t operation;
+    Il2CppObject *callback;
+    Il2CppObject *state;
+} Il2CppIOSelectorJob;
+typedef enum
+{
+    Il2Cpp_CallType_Sync = 0,
+    Il2Cpp_CallType_BeginInvoke = 1,
+    Il2Cpp_CallType_EndInvoke = 2,
+    Il2Cpp_CallType_OneWay = 3
+} Il2CppCallType;
+typedef struct Il2CppMethodMessage
+{
+    Il2CppObject obj;
+    Il2CppReflectionMethod *method;
+    Il2CppArray *args;
+    Il2CppArray *names;
+    Il2CppArray *arg_types;
+    Il2CppObject *ctx;
+    Il2CppObject *rval;
+    Il2CppObject *exc;
+    Il2CppAsyncResult *async_result;
+    uint32_t call_type;
+} Il2CppMethodMessage;
+typedef struct Il2CppAppDomainSetup
+{
+    Il2CppObject object;
+    Il2CppString* application_base;
+    Il2CppString* application_name;
+    Il2CppString* cache_path;
+    Il2CppString* configuration_file;
+    Il2CppString* dynamic_base;
+    Il2CppString* license_file;
+    Il2CppString* private_bin_path;
+    Il2CppString* private_bin_path_probe;
+    Il2CppString* shadow_copy_directories;
+    Il2CppString* shadow_copy_files;
+    uint8_t publisher_policy;
+    uint8_t path_changed;
+    int loader_optimization;
+    uint8_t disallow_binding_redirects;
+    uint8_t disallow_code_downloads;
+    Il2CppObject* activation_arguments;
+    Il2CppObject* domain_initializer;
+    Il2CppObject* application_trust;
+    Il2CppArray* domain_initializer_args;
+    uint8_t disallow_appbase_probe;
+    Il2CppArray* configuration_bytes;
+    Il2CppArray* serialized_non_primitives;
+} Il2CppAppDomainSetup;
+typedef struct Il2CppException
+{
+    Il2CppObject object;
+    Il2CppString* className;
+    Il2CppString* message;
+    Il2CppObject* _data;
+    Il2CppException* inner_ex;
+    Il2CppString* _helpURL;
+    Il2CppArray* trace_ips;
+    Il2CppString* stack_trace;
+    Il2CppString* remote_stack_trace;
+    int remote_stack_index;
+    Il2CppObject* _dynamicMethods;
+    il2cpp_hresult_t hresult;
+    Il2CppString* source;
+    Il2CppObject* safeSerializationManager;
+    Il2CppArray* captured_traces;
+    Il2CppArray* native_trace_ips;
+} Il2CppException;
+typedef struct Il2CppSystemException
+{
+    Il2CppException base;
+} Il2CppSystemException;
+typedef struct Il2CppArgumentException
+{
+    Il2CppException base;
+    Il2CppString *argName;
+} Il2CppArgumentException;
+typedef struct Il2CppTypedRef
+{
+    const Il2CppType *type;
+    void* value;
+    Il2CppClass *klass;
+} Il2CppTypedRef;
+typedef struct Il2CppDelegate
+{
+    Il2CppObject object;
+    Il2CppMethodPointer method_ptr;
+    InvokerMethod invoke_impl;
+    Il2CppObject *target;
+    const MethodInfo *method;
+    void* delegate_trampoline;
+    intptr_t extraArg;
+    uint8_t **method_code;
+    Il2CppReflectionMethod *method_info;
+    Il2CppReflectionMethod *original_method_info;
+    Il2CppObject *data;
+    uint8_t method_is_virtual;
+} Il2CppDelegate;
+typedef struct Il2CppMulticastDelegate
+{
+    Il2CppDelegate delegate;
+    Il2CppArray *delegates;
+} Il2CppMulticastDelegate;
+typedef struct Il2CppMarshalByRefObject
+{
+    Il2CppObject obj;
+    Il2CppObject *identity;
+} Il2CppMarshalByRefObject;
+typedef struct Il2CppAppDomain
+{
+    Il2CppMarshalByRefObject mbr;
+    Il2CppDomain *data;
+} Il2CppAppDomain;
+typedef struct Il2CppStackFrame
+{
+    Il2CppObject obj;
+    int32_t il_offset;
+    int32_t native_offset;
+    uint64_t methodAddress;
+    uint32_t methodIndex;
+    Il2CppReflectionMethod *method;
+    Il2CppString *filename;
+    int32_t line;
+    int32_t column;
+    Il2CppString *internal_method_name;
+} Il2CppStackFrame;
+typedef struct Il2CppDateTimeFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppObject* CultureData;
+    Il2CppString* Name;
+    Il2CppString* LangName;
+    Il2CppObject* CompareInfo;
+    Il2CppObject* CultureInfo;
+    Il2CppString* AMDesignator;
+    Il2CppString* PMDesignator;
+    Il2CppString* DateSeparator;
+    Il2CppString* GeneralShortTimePattern;
+    Il2CppString* GeneralLongTimePattern;
+    Il2CppString* TimeSeparator;
+    Il2CppString* MonthDayPattern;
+    Il2CppString* DateTimeOffsetPattern;
+    Il2CppObject* Calendar;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+    Il2CppString* FullDateTimePattern;
+    Il2CppArray* AbbreviatedDayNames;
+    Il2CppArray* ShortDayNames;
+    Il2CppArray* DayNames;
+    Il2CppArray* AbbreviatedMonthNames;
+    Il2CppArray* MonthNames;
+    Il2CppArray* GenitiveMonthNames;
+    Il2CppArray* GenitiveAbbreviatedMonthNames;
+    Il2CppArray* LeapYearMonthNames;
+    Il2CppString* LongDatePattern;
+    Il2CppString* ShortDatePattern;
+    Il2CppString* YearMonthPattern;
+    Il2CppString* LongTimePattern;
+    Il2CppString* ShortTimePattern;
+    Il2CppArray* YearMonthPatterns;
+    Il2CppArray* ShortDatePatterns;
+    Il2CppArray* LongDatePatterns;
+    Il2CppArray* ShortTimePatterns;
+    Il2CppArray* LongTimePatterns;
+    Il2CppArray* EraNames;
+    Il2CppArray* AbbrevEraNames;
+    Il2CppArray* AbbrevEnglishEraNames;
+    Il2CppArray* OptionalCalendars;
+    uint8_t readOnly;
+    int32_t FormatFlags;
+    int32_t CultureID;
+    uint8_t UseUserOverride;
+    uint8_t UseCalendarInfo;
+    int32_t DataItem;
+    uint8_t IsDefaultCalendar;
+    Il2CppArray* DateWords;
+    Il2CppString* FullTimeSpanPositivePattern;
+    Il2CppString* FullTimeSpanNegativePattern;
+    Il2CppArray* dtfiTokenHash;
+} Il2CppDateTimeFormatInfo;
+typedef struct Il2CppNumberFormatInfo
+{
+    Il2CppObject obj;
+    Il2CppArray* numberGroupSizes;
+    Il2CppArray* currencyGroupSizes;
+    Il2CppArray* percentGroupSizes;
+    Il2CppString* positiveSign;
+    Il2CppString* negativeSign;
+    Il2CppString* numberDecimalSeparator;
+    Il2CppString* numberGroupSeparator;
+    Il2CppString* currencyGroupSeparator;
+    Il2CppString* currencyDecimalSeparator;
+    Il2CppString* currencySymbol;
+    Il2CppString* ansiCurrencySymbol;
+    Il2CppString* naNSymbol;
+    Il2CppString* positiveInfinitySymbol;
+    Il2CppString* negativeInfinitySymbol;
+    Il2CppString* percentDecimalSeparator;
+    Il2CppString* percentGroupSeparator;
+    Il2CppString* percentSymbol;
+    Il2CppString* perMilleSymbol;
+    Il2CppArray* nativeDigits;
+    int dataItem;
+    int numberDecimalDigits;
+    int currencyDecimalDigits;
+    int currencyPositivePattern;
+    int currencyNegativePattern;
+    int numberNegativePattern;
+    int percentPositivePattern;
+    int percentNegativePattern;
+    int percentDecimalDigits;
+    int digitSubstitution;
+    uint8_t readOnly;
+    uint8_t useUserOverride;
+    uint8_t isInvariant;
+    uint8_t validForParseAsNumber;
+    uint8_t validForParseAsCurrency;
+} Il2CppNumberFormatInfo;
+typedef struct Il2CppCultureData
+{
+    Il2CppObject obj;
+    Il2CppString *AMDesignator;
+    Il2CppString *PMDesignator;
+    Il2CppString *TimeSeparator;
+    Il2CppArray *LongTimePatterns;
+    Il2CppArray *ShortTimePatterns;
+    uint32_t FirstDayOfWeek;
+    uint32_t CalendarWeekRule;
+} Il2CppCultureData;
+typedef struct Il2CppCalendarData
+{
+    Il2CppObject obj;
+    Il2CppString *NativeName;
+    Il2CppArray *ShortDatePatterns;
+    Il2CppArray *YearMonthPatterns;
+    Il2CppArray *LongDatePatterns;
+    Il2CppString *MonthDayPattern;
+    Il2CppArray *EraNames;
+    Il2CppArray *AbbreviatedEraNames;
+    Il2CppArray *AbbreviatedEnglishEraNames;
+    Il2CppArray *DayNames;
+    Il2CppArray *AbbreviatedDayNames;
+    Il2CppArray *SuperShortDayNames;
+    Il2CppArray *MonthNames;
+    Il2CppArray *AbbreviatedMonthNames;
+    Il2CppArray *GenitiveMonthNames;
+    Il2CppArray *GenitiveAbbreviatedMonthNames;
+} Il2CppCalendarData;
+typedef struct Il2CppCultureInfo
+{
+    Il2CppObject obj;
+    uint8_t is_read_only;
+    int32_t lcid;
+    int32_t parent_lcid;
+    int32_t datetime_index;
+    int32_t number_index;
+    int32_t default_calendar_type;
+    uint8_t use_user_override;
+    Il2CppNumberFormatInfo* number_format;
+    Il2CppDateTimeFormatInfo* datetime_format;
+    Il2CppObject* textinfo;
+    Il2CppString* name;
+    Il2CppString* englishname;
+    Il2CppString* nativename;
+    Il2CppString* iso3lang;
+    Il2CppString* iso2lang;
+    Il2CppString* win3lang;
+    Il2CppString* territory;
+    Il2CppArray* native_calendar_names;
+    Il2CppString* compareinfo;
+    const void* text_info_data;
+    int dataItem;
+    Il2CppObject* calendar;
+    Il2CppObject* parent_culture;
+    uint8_t constructed;
+    Il2CppArray* cached_serialized_form;
+    Il2CppObject* cultureData;
+    uint8_t isInherited;
+} Il2CppCultureInfo;
+typedef struct Il2CppRegionInfo
+{
+    Il2CppObject obj;
+    int32_t geo_id;
+    Il2CppString* iso2name;
+    Il2CppString* iso3name;
+    Il2CppString* win3name;
+    Il2CppString* english_name;
+    Il2CppString* native_name;
+    Il2CppString* currency_symbol;
+    Il2CppString* iso_currency_symbol;
+    Il2CppString* currency_english_name;
+    Il2CppString* currency_native_name;
+} Il2CppRegionInfo;
+typedef struct Il2CppSafeHandle
+{
+    Il2CppObject base;
+    void* handle;
+    int state;
+    uint8_t owns_handle;
+    uint8_t fullyInitialized;
+} Il2CppSafeHandle;
+typedef struct Il2CppStringBuilder Il2CppStringBuilder;
+typedef struct Il2CppStringBuilder
+{
+    Il2CppObject object;
+    Il2CppArray* chunkChars;
+    Il2CppStringBuilder* chunkPrevious;
+    int chunkLength;
+    int chunkOffset;
+    int maxCapacity;
+} Il2CppStringBuilder;
+typedef struct Il2CppSocketAddress
+{
+    Il2CppObject base;
+    int m_Size;
+    Il2CppArray* data;
+    uint8_t m_changed;
+    int m_hash;
+} Il2CppSocketAddress;
+typedef struct Il2CppSortKey
+{
+    Il2CppObject base;
+    Il2CppString *str;
+    Il2CppArray *key;
+    int32_t options;
+    int32_t lcid;
+} Il2CppSortKey;
+typedef struct Il2CppErrorWrapper
+{
+    Il2CppObject base;
+    int32_t errorCode;
+} Il2CppErrorWrapper;
+typedef struct Il2CppAsyncResult
+{
+    Il2CppObject base;
+    Il2CppObject *async_state;
+    Il2CppWaitHandle *handle;
+    Il2CppDelegate *async_delegate;
+    void* data;
+    Il2CppAsyncCall *object_data;
+    uint8_t sync_completed;
+    uint8_t completed;
+    uint8_t endinvoke_called;
+    Il2CppObject *async_callback;
+    Il2CppObject *execution_context;
+    Il2CppObject *original_context;
+} Il2CppAsyncResult;
+typedef struct Il2CppAsyncCall
+{
+    Il2CppObject base;
+    Il2CppMethodMessage *msg;
+    MethodInfo *cb_method;
+    Il2CppDelegate *cb_target;
+    Il2CppObject *state;
+    Il2CppObject *res;
+    Il2CppArray *out_args;
+} Il2CppAsyncCall;
+typedef struct Il2CppExceptionWrapper Il2CppExceptionWrapper;
+typedef struct Il2CppExceptionWrapper
+{
+    Il2CppException* ex;
+} Il2CppExceptionWrapper;
+typedef struct Il2CppIOAsyncResult
+{
+    Il2CppObject base;
+    Il2CppDelegate* callback;
+    Il2CppObject* state;
+    Il2CppWaitHandle* wait_handle;
+    uint8_t completed_synchronously;
+    uint8_t completed;
+} Il2CppIOAsyncResult;
+typedef struct Il2CppSocketAsyncResult
+{
+    Il2CppIOAsyncResult base;
+    Il2CppObject* socket;
+    int32_t operation;
+    Il2CppException* delayedException;
+    Il2CppObject* endPoint;
+    Il2CppArray* buffer;
+    int32_t offset;
+    int32_t size;
+    int32_t socket_flags;
+    Il2CppObject* acceptSocket;
+    Il2CppArray* addresses;
+    int32_t port;
+    Il2CppObject* buffers;
+    uint8_t reuseSocket;
+    int32_t currentAddress;
+    Il2CppObject* acceptedSocket;
+    int32_t total;
+    int32_t error;
+    int32_t endCalled;
+} Il2CppSocketAsyncResult;
+typedef enum Il2CppResourceLocation
+{
+    IL2CPP_RESOURCE_LOCATION_EMBEDDED = 1,
+    IL2CPP_RESOURCE_LOCATION_ANOTHER_ASSEMBLY = 2,
+    IL2CPP_RESOURCE_LOCATION_IN_MANIFEST = 4
+} Il2CppResourceLocation;
+typedef struct Il2CppManifestResourceInfo
+{
+    Il2CppObject object;
+    Il2CppReflectionAssembly* assembly;
+    Il2CppString* filename;
+    uint32_t location;
+} Il2CppManifestResourceInfo;
+typedef struct Il2CppAppContext
+{
+    Il2CppObject obj;
+    int32_t domain_id;
+    int32_t context_id;
+    void* static_data;
+} Il2CppAppContext;
+typedef struct Il2CppDecimal
+{
+    uint16_t reserved;
+    union
+    {
+        struct
+        {
+            uint8_t scale;
+            uint8_t sign;
+        } u;
+        uint16_t signscale;
+    } u;
+    uint32_t Hi32;
+    union
+    {
+        struct
+        {
+            uint32_t Lo32;
+            uint32_t Mid32;
+        } v;
+        uint64_t Lo64;
+    } v;
+} Il2CppDecimal;
+typedef struct Il2CppDouble
+{
+    uint32_t mantLo : 32;
+    uint32_t mantHi : 20;
+    uint32_t exp : 11;
+    uint32_t sign : 1;
+} Il2CppDouble;
+typedef union Il2CppDouble_double
+{
+    Il2CppDouble s;
+    double d;
+} Il2CppDouble_double;
+typedef enum Il2CppDecimalCompareResult
+{
+    IL2CPP_DECIMAL_CMP_LT = -1,
+    IL2CPP_DECIMAL_CMP_EQ,
+    IL2CPP_DECIMAL_CMP_GT
+} Il2CppDecimalCompareResult;
+typedef struct Il2CppSingle
+{
+    uint32_t mant : 23;
+    uint32_t exp : 8;
+    uint32_t sign : 1;
+} Il2CppSingle;
+typedef union Il2CppSingle_float
+{
+    Il2CppSingle s;
+    float f;
+} Il2CppSingle_float;

--- a/Il2CppInspector.Common/Outputs/Data/README.md
+++ b/Il2CppInspector.Common/Outputs/Data/README.md
@@ -1,0 +1,31 @@
+﻿These headers were built using roughly the following approach:
+
+- Paste the following headers together in this order (skipping any missing ones):
+
+		il2cpp-config.h
+
+		blob.h
+		il2cpp-blob.h
+
+		il2cpp-metadata.h
+		metadata.h
+
+		il2cpp-api-types.h
+		types.h
+		il2cpp-string-types.h
+
+		il2cpp-runtime-metadata.h
+
+		class-internals.h
+		il2cpp-class-internals.h
+
+		object-internals.h
+		il2cpp-object-internals.h
+
+- Remove any lines starting with `#include "` or `#pragma once`
+- Manually fix the header until it compiles under `g++ header.h -o /dev/null`
+	- This usually just means removing or commenting out offending constructs
+- Preprocess the header using `grep -v '#include' HEADER.h | cpp -xc -P -E - > HEADER.i` to simplify it
+- Manually fix the header until IDA will import it without errors
+- Split the `Il2CppClass` structure (to allow `static_fields` and `vtable` to be typed per-class), add padding to `cctor_thread` if necessary, and expand zero-length structs
+- Import the final `.i` file into this directory and specify `Build Action -> Embedded Resource`

--- a/Il2CppInspector.Common/Outputs/Data/ResourceReader.cs
+++ b/Il2CppInspector.Common/Outputs/Data/ResourceReader.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using System.IO;
+
+namespace Il2CppInspector.Outputs.Data
+{
+    public class ResourceReader
+    {
+        public static string ReadFileAsString(string name) {
+            string resourceName = typeof(ResourceReader).Namespace + "." + name;
+            Assembly assembly = Assembly.GetCallingAssembly();
+            using Stream stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream == null) {
+                throw new FileNotFoundException(name);
+            }
+            using StreamReader reader = new StreamReader(stream);
+            string result = reader.ReadToEnd();
+            return result;
+        }
+    }
+}

--- a/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
+++ b/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
@@ -174,7 +174,7 @@ def MakeFunction(start, end):
         private void writeFunctions() {
             foreach (var func in model.Package.FunctionAddresses)
                 if (func.Key != func.Value)
-                    writeLine($"MakeFunction({func.Key.ToAddressString()}, {func.Value.ToAddressString()})");
+                    writeLine($"idc.MakeFunction({func.Key.ToAddressString()})");
         }
 
         private void writeMetadata() {

--- a/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
+++ b/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
@@ -316,7 +316,7 @@ def SetName(addr, name):
                     csrc.Append($"struct {cName}__Fields {{\n");
 
                 bool empty = true;
-                foreach (var field in ti.DeclaredFields.Where((x) => (x.IsStatic == isStatic)).OrderBy((x) => x.Offset)) {
+                foreach (var field in ti.DeclaredFields.Where((x) => (x.IsStatic == isStatic))) {
                     string name = fieldNamer.GetName(field);
                     var fti = field.FieldType;
                     if (fti.ContainsGenericParameters) {

--- a/Il2CppInspector.Common/Reflection/Il2CppModel.cs
+++ b/Il2CppInspector.Common/Reflection/Il2CppModel.cs
@@ -229,6 +229,25 @@ namespace Il2CppInspector.Reflection
             return result;
         }
 
+        public MethodBase[] GetVTable(TypeInfo ti) {
+            var definition = ti.Definition;
+            if (definition == null)
+                definition = ti.GetGenericTypeDefinition().Definition;
+
+            MetadataUsage[] vt = Package.GetVTable(definition);
+            MethodBase[] res = new MethodBase[vt.Length];
+            for (int i = 0; i < vt.Length; i++) {
+                if (vt[i].Type == MetadataUsageType.MethodRef) {
+                    res[i] = MethodsByReferenceIndex[vt[i].SourceIndex];
+                } else if (vt[i].Type == MetadataUsageType.MethodDef) {
+                    res[i] = MethodsByDefinitionIndex[vt[i].SourceIndex];
+                } else {
+                    res[i] = null;
+                }
+            }
+            return res;
+        }
+
         // The attribute index is an index into AttributeTypeRanges, each of which is a start-end range index into AttributeTypeIndices, each of which is a TypeIndex
         public int GetCustomAttributeIndex(Assembly asm, uint token, int customAttributeIndex) {
             // Prior to v24.1, Type, Field, Parameter, Method, Event, Property, Assembly definitions had their own customAttributeIndex field

--- a/Il2CppInspector.Common/Reflection/Il2CppModel.cs
+++ b/Il2CppInspector.Common/Reflection/Il2CppModel.cs
@@ -53,9 +53,10 @@ namespace Il2CppInspector.Reflection
         public TypeInfo GetType(string fullName) => Types.FirstOrDefault(t => fullName == t.Namespace + "." + t.Name);
 
         // Get a concrete instantiation of a generic method from its fully qualified name and type arguments
-        public MethodBase GetGenericMethod(string fullName, params TypeInfo[] typeArguments) =>
+        public MethodBase GetGenericMethod(string fullName, TypeInfo[] genericTypeArguments, TypeInfo[] genericMethodArguments) =>
             MethodsByReferenceIndex.First(m => fullName == m.DeclaringType.Namespace + "." + m.DeclaringType.BaseName + "." + m.Name
-            && m.GetGenericArguments().SequenceEqual(typeArguments));
+            && m.DeclaringType.GetGenericArguments().SequenceEqual(genericTypeArguments)
+            && m.GetGenericArguments().SequenceEqual(genericMethodArguments));
 
         // Create type model
         public Il2CppModel(Il2CppInspector package) {

--- a/Il2CppInspector.Common/Reflection/Il2CppModel.cs
+++ b/Il2CppInspector.Common/Reflection/Il2CppModel.cs
@@ -75,6 +75,9 @@ namespace Il2CppInspector.Reflection
             // Create and reference types from TypeRefs
             // Note that you can't resolve any TypeRefs until all the TypeDefs have been processed
             for (int typeRefIndex = 0; typeRefIndex < package.TypeReferences.Count; typeRefIndex++) {
+                if (TypesByReferenceIndex[typeRefIndex] != null)
+                    continue;
+
                 var typeRef = Package.TypeReferences[typeRefIndex];
                 var referencedType = resolveTypeReference(typeRef);
 

--- a/Il2CppInspector.Common/Reflection/MemberInfo.cs
+++ b/Il2CppInspector.Common/Reflection/MemberInfo.cs
@@ -21,7 +21,8 @@ namespace Il2CppInspector.Reflection {
 
         // Type that this type is declared in for nested types
         protected int declaringTypeDefinitionIndex { private get; set; } = -1;
-        public TypeInfo DeclaringType => declaringTypeDefinitionIndex != -1? Assembly.Model.TypesByDefinitionIndex[declaringTypeDefinitionIndex] : null;
+        protected TypeInfo declaringType;
+        public TypeInfo DeclaringType => declaringType ?? (declaringTypeDefinitionIndex != -1? Assembly.Model.TypesByDefinitionIndex[declaringTypeDefinitionIndex] : null);
 
         // What sort of member this is, eg. method, field etc.
         public abstract MemberTypes MemberType { get; }
@@ -39,7 +40,7 @@ namespace Il2CppInspector.Reflection {
         protected MemberInfo(TypeInfo declaringType = null) {
             if (declaringType != null) {
                 Assembly = declaringType.Assembly;
-                declaringTypeDefinitionIndex = declaringType.Index;
+                this.declaringType = declaringType;
             }
         }
 

--- a/Il2CppInspector.Common/Reflection/MethodInfo.cs
+++ b/Il2CppInspector.Common/Reflection/MethodInfo.cs
@@ -33,9 +33,15 @@ namespace Il2CppInspector.Reflection
         public MethodInfo(Il2CppModel model, Il2CppMethodSpec spec, TypeInfo declaringType) : base(model, spec, declaringType) {
             var methodDef = model.MethodsByDefinitionIndex[spec.methodDefinitionIndex];
 
-            // Add return parameter
             returnTypeReference = methodDef.Definition.returnType;
-            ReturnParameter = ((MethodInfo) methodDef).ReturnParameter;
+            ReturnParameter = ((MethodInfo)methodDef).ReturnParameter;
+
+            var ptype = ReturnParameter.ParameterType;
+            if (ptype.IsGenericMethodParameter) {
+                ReturnParameter = new ParameterInfo(model, ReturnParameter, GetGenericArguments()[ptype.GenericParameterPosition]);
+            } else if (ptype.IsGenericTypeParameter) {
+                ReturnParameter = new ParameterInfo(model, ReturnParameter, declaringType.GetGenericArguments()[ptype.GenericParameterPosition]);
+            }
         }
 
         public override string ToString() => ReturnType.Name + " " + Name + GetFullTypeParametersString() + "(" + string.Join(", ", 

--- a/Il2CppInspector.Common/Reflection/TypeInfo.cs
+++ b/Il2CppInspector.Common/Reflection/TypeInfo.cs
@@ -32,7 +32,7 @@ namespace Il2CppInspector.Reflection {
                 : null;
 
         // True if the type contains unresolved generic type parameters
-        public bool ContainsGenericParameters => IsGenericParameter || genericArguments.Any(ga => ga.ContainsGenericParameters);
+        public bool ContainsGenericParameters => (HasElementType && ElementType.ContainsGenericParameters) || IsGenericParameter || genericArguments.Any(ga => ga.ContainsGenericParameters);
 
         public string BaseName => base.Name;
 

--- a/Il2CppInspector.Common/Reflection/TypeInfo.cs
+++ b/Il2CppInspector.Common/Reflection/TypeInfo.cs
@@ -640,7 +640,7 @@ namespace Il2CppInspector.Reflection {
                     baseTypeReference = ownerType.Definition.parentIndex;
 
                 // Nested type always - sets DeclaringType used below
-                declaringTypeDefinitionIndex = ownerType.Index;
+                declaringType = ownerType;
                 MemberType |= MemberTypes.NestedType;
 
                 // All generic method type parameters have a declared method

--- a/Il2CppInspector.Common/Reflection/TypeInfo.cs
+++ b/Il2CppInspector.Common/Reflection/TypeInfo.cs
@@ -601,6 +601,7 @@ namespace Il2CppInspector.Reflection {
 
                 var genericTypeDef = model.TypesByDefinitionIndex[generic.typeDefinitionIndex];
 
+                Definition = genericTypeDef.Definition;
                 Assembly = genericTypeDef.Assembly;
                 Namespace = genericTypeDef.Namespace;
                 Name = genericTypeDef.BaseName;
@@ -671,6 +672,7 @@ namespace Il2CppInspector.Reflection {
                         ? model.Package.Methods[container.ownerIndex].declaringType
                         : container.ownerIndex];
 
+                Definition = ownerType.Definition;
                 Assembly = ownerType.Assembly;
                 Namespace = "";
                 Name = model.Package.Strings[paramType.nameIndex];
@@ -699,7 +701,8 @@ namespace Il2CppInspector.Reflection {
         // Initialize a type from a concrete generic instance (TypeSpec)
         public TypeInfo(Il2CppModel model, Il2CppMethodSpec spec) {
             var genericTypeDefinition = model.MethodsByDefinitionIndex[spec.methodDefinitionIndex].DeclaringType;
-
+            
+            Definition = genericTypeDefinition.Definition;
             // Same visibility attributes as generic type definition
             Attributes = genericTypeDefinition.Attributes;
 
@@ -728,6 +731,8 @@ namespace Il2CppInspector.Reflection {
         public TypeInfo(TypeInfo declaringType, Il2CppGenericParameter param) : base(declaringType) {
             // Same visibility attributes as declaring type
             Attributes = declaringType.Attributes;
+
+            Definition = declaringType.Definition;
 
             // Same namespace as declaring type
             Namespace = declaringType.Namespace;

--- a/Il2CppTests/TestGenerics.cs
+++ b/Il2CppTests/TestGenerics.cs
@@ -49,12 +49,26 @@ namespace Il2CppInspector
             MethodInfo mGMDIGC = tGCWM.GetMethod("GenericMethodDefinitionInGenericClass");
             MethodInfo mGMDIGC2 = tGCWM.GetMethod("GenericMethodDefinitionInGenericClass2");
 
+            MethodBase mNGMIGC_closed = model.GetGenericMethod(
+                "Il2CppTests.TestSources.GenericClassWithMethods`1.NonGenericMethodInGenericClass",
+                new TypeInfo[] { model.GetType("System.Int32") },
+                new TypeInfo[] { });
+            MethodBase mNGMIGC2_closed = model.GetGenericMethod(
+                "Il2CppTests.TestSources.GenericClassWithMethods`1.NonGenericMethodInGenericClass2",
+                new TypeInfo[] { model.GetType("System.Int32") },
+                new TypeInfo[] { });
             MethodBase mGMDINGC_closed = model.GetGenericMethod(
-                "Il2CppTests.TestSources.NonGeneric.GenericMethodDefinitionInNonGenericClass", model.GetType("System.Single"));
+                "Il2CppTests.TestSources.NonGeneric.GenericMethodDefinitionInNonGenericClass",
+                new TypeInfo[] { },
+                new TypeInfo[] { model.GetType("System.Single") });
             MethodBase mGMDIGC_closed = model.GetGenericMethod(
-                "Il2CppTests.TestSources.GenericClassWithMethods`1.GenericMethodDefinitionInGenericClass", model.GetType("System.Int32"));
+                "Il2CppTests.TestSources.GenericClassWithMethods`1.GenericMethodDefinitionInGenericClass",
+                new TypeInfo[] { model.GetType("System.Int32") },
+                new TypeInfo[] { model.GetType("System.Int32") });
             MethodBase mGMDIGC2_closed = model.GetGenericMethod(
-                "Il2CppTests.TestSources.GenericClassWithMethods`1.GenericMethodDefinitionInGenericClass2", model.GetType("System.String"));
+                "Il2CppTests.TestSources.GenericClassWithMethods`1.GenericMethodDefinitionInGenericClass2",
+                new TypeInfo[] { model.GetType("System.Int32") },
+                new TypeInfo[] { model.GetType("System.String") });
 
             DisplayGenericType(tBase, "Generic type definition Base<T, U>");
             DisplayGenericType(tDerived, "Derived<V>");
@@ -85,13 +99,10 @@ namespace Il2CppInspector
                 (mGMDIGC2, "Void GenericMethodDefinitionInGenericClass2[U](T, U)", true, true, true, false),
 
                 (mGMDINGC_closed, "Void GenericMethodDefinitionInNonGenericClass[Single](Single)", true, false, false, true),
-                // TODO: We can't test non-generic methods in a generic class until we've implemented parameter substitution in TypeInfo constructor
-                /*
                 (mNGMIGC_closed,  "Void NonGenericMethodInGenericClass(Int32)", false, false, false, false),
-                (mNGMIGC2_closed, "Void NonGenericMethodInGenericClass()", false, false, false, false),
-                */
-                (mGMDIGC_closed,  "Void GenericMethodDefinitionInGenericClass[Int32](Int32)", true, true, false, true),
-                (mGMDIGC2_closed, "Void GenericMethodDefinitionInGenericClass2[String](T, String)", true, true, false, true) // It's actually System.String in .NET
+                (mNGMIGC2_closed, "Void NonGenericMethodInGenericClass2()", false, false, false, false),
+                (mGMDIGC_closed,  "Void GenericMethodDefinitionInGenericClass[Int32](Int32)", true, false, false, true),
+                (mGMDIGC2_closed, "Void GenericMethodDefinitionInGenericClass2[String](Int32, String)", true, false, false, true) // It's actually System.String in .NET
             };
 
             foreach (var check in typeChecks) {

--- a/Il2CppTests/TestRunner.cs
+++ b/Il2CppTests/TestRunner.cs
@@ -43,12 +43,19 @@ namespace Il2CppInspector
 
             // Dump each image in the binary separately
             int i = 0;
-            foreach (var il2cpp in inspectors)
-                new CSharpCodeStubs(new Il2CppModel(il2cpp)) {
-                        ExcludedNamespaces = Constants.DefaultExcludedNamespaces,
-                        SuppressMetadata = false,
-                        MustCompile = true
-                }.WriteSingleFile(testPath + @"\test-result" + (i++ > 0 ? "-" + (i - 1) : "") + ".cs");
+            foreach (var il2cpp in inspectors) {
+                var model = new Il2CppModel(il2cpp);
+                var nameSuffix = i++ > 0 ? "-" + (i - 1) : "";
+                
+                new CSharpCodeStubs(model) {
+                    ExcludedNamespaces = Constants.DefaultExcludedNamespaces,
+                    SuppressMetadata = false,
+                    MustCompile = true
+                }.WriteSingleFile(testPath + $@"\test-result{nameSuffix}.cs");
+
+                new IDAPythonScript(model)
+                    .WriteScriptToFile(testPath + $@"\test-ida-result{nameSuffix}.py");
+            }
 
             // Compare test result with expected result
             for (i = 0; i < inspectors.Count; i++) {


### PR DESCRIPTION
This patch augments the IDA output module to add structure, function and TypeInfo types, which enable IDA to automatically resolve structure offsets and improve the decompilation massively. Take a look at the following decompiler sample (IDA 7.0, x86) for a pretty much randomly chosen function:

**Before**:
```c
// Int32 GetParametersCount()
int __cdecl MethodBase_GetParametersCount(int a1)
{
  int v1; // eax

  v1 = (*(int (__cdecl **)(int, _DWORD))(*(_DWORD *)a1 + 484))(a1, *(_DWORD *)(*(_DWORD *)a1 + 488));
  if ( !v1 )
    sub_100CCC90();
  return *(_DWORD *)(v1 + 12);
}
```

**After** (`v1` manually annotated with `ParameterInfo__Array *` type)
```c
// Int32 GetParametersCount()
int32_t __cdecl MethodBase_GetParametersCount(struct MethodBase *this)
{
  ParameterInfo__Array *v1; // eax

  v1 = (ParameterInfo__Array *)((int (__cdecl *)(struct MethodBase *, const void *))this->klass->vtable.GetParametersInternal.methodPtr)(
                                 this,
                                 this->klass->vtable.GetParametersInternal.method);
  if ( !v1 )
    sub_100CCC90();
  return v1->max_length;
}
```

Across the board, this patch enables IDA to automatically pick up static fields (via typed `TypeInfo` structs), regular fields (via typed value and reference class structures), vtables (via `TypeInfo` structs), and even interface calls if the relevant `InterfaceInvoker` code has been inlined. By typing all functions, it produces significantly better code for direct function calls, and improves type inference.

Unfortunately, I'm not that proficient with the internals of Il2CppInspector or with Il2Cpp metadata, so there are a few current limitations to be aware of:

- vtables have no types. This is probably an easy fix, except for:
- generics basically don't work at all. I could not figure out how to *easily* monomorphize generics, especially genericized vtables. Most of this is just me not fully understanding how generics work. This unfortunately breaks generic fields and makes their offsets wrong, so it's definitely something that needs to be fixed.
- this requires the `Il2CppClass` structure for the specific version of Il2Cpp being targeted. I don't have access to the headers for historic versions of Il2Cpp, so I couldn't add their headers.
- this is untested on anything except MSVC-produced x86/x64 .dlls on Windows. More testing is needed for different environments (particularly, calling conventions might need adjusting on other platforms).

If anyone could provide a little nudge towards any of these issues, I'll happily work on them. I'm leaving this as a draft right now but would appreciate feedback at this stage on anything (code quality, general approach, willingness to merge, etc.) so I can make adjustments.