### PR TITLE
Fix CSharp output paths on POSIX filesystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# User-specific files (VSCode)
+.vscode
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/Il2CppInspector.CLI/Utils.cs
+++ b/Il2CppInspector.CLI/Utils.cs
@@ -16,7 +16,7 @@ namespace Il2CppInspector
             if (absolutePath.IndexOf("*", StringComparison.Ordinal) == -1)
                 return absolutePath;
 
-            Regex sections = new Regex(@"((?:[^*]*)\\)((?:.*?)\*.*?)(?:$|\\)");
+            Regex sections = new Regex(string.Format(@"((?:[^*]*){0})((?:.*?)\*.*?)(?:$|{0})", Path.DirectorySeparatorChar));
             var matches = sections.Matches(absolutePath);
 
             var pathLength = 0;
@@ -32,7 +32,7 @@ namespace Il2CppInspector
                     .OrderByDescending(x => x)
                     .FirstOrDefault();
 
-                path = dir + @"\";
+                path = dir + Path.DirectorySeparatorChar;
                 pathLength += match.Groups[1].Value.Length + match.Groups[2].Value.Length + 1;
             }
 


### PR DESCRIPTION
When attempting to write to a directory, the program would create a mess of files in a single directory, ex. in tree output, it would output files named like `System\\Collections\\Generic.cs`. This hotfix resolves this issue

Should work on all supported OSs, since this solution uses plenty of `Path.Combine` and `Path.DirectorySeparatorChar`