### PR TITLE
Compatibility fixes for multiple versions

### DIFF
--- a/Il2CppInspector.Common/Architectures/Il2CppBinaryX64.cs
+++ b/Il2CppInspector.Common/Architectures/Il2CppBinaryX64.cs
@@ -214,7 +214,7 @@ namespace Il2CppInspector
                     offset = nextLea?.foundOffset + leaSize ?? buff2Size;
                 }
 
-                if (leas.Count == 3) {
+                if ((image.Version < 21 && leas.Count == 2) || (image.Version >= 21 && leas.Count == 3)) {
                     // Register-based argument passing?
                     var leaRSI = leas.FirstOrDefault(l => l.Value == RSI).Key.address;
                     var leaRDI = leas.FirstOrDefault(l => l.Value == RDI).Key.address;

--- a/Il2CppInspector.Common/Architectures/Il2CppBinaryX86.cs
+++ b/Il2CppInspector.Common/Architectures/Il2CppBinaryX86.cs
@@ -32,10 +32,17 @@ namespace Il2CppInspector
                     return (0, 0);
 
                 // Jump to Il2CppCodegenRegistration
-                image.Position = image.MapVATR((ulong) pCgr + 6);
-                metadata = image.ReadUInt32();
-                image.Position = image.MapVATR((ulong) pCgr + 11);
-                code = image.ReadUInt32();
+                if(image.Version < 21) {
+                    image.Position = image.MapVATR((ulong)pCgr + 1);
+                    metadata = image.ReadUInt32();
+                    image.Position = image.MapVATR((ulong)pCgr + 6);
+                    code = image.ReadUInt32();
+                } else {
+                    image.Position = image.MapVATR((ulong)pCgr + 6);
+                    metadata = image.ReadUInt32();
+                    image.Position = image.MapVATR((ulong)pCgr + 11);
+                    code = image.ReadUInt32();
+                }
                 return (code, metadata);
             }
 

--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
@@ -181,6 +181,13 @@ namespace Il2CppInspector
             if (Image.Version >= 24.2) {
                 Modules = new Dictionary<string, Il2CppCodeGenModule>();
 
+                // In v24.3, windowsRuntimeFactoryTable collides with codeGenModules. So far no samples have had windowsRuntimeFactoryCount > 0;
+                // if this changes we'll have to get smarter about disambiguating these two.
+                if (CodeRegistration.codeGenModulesCount == 0) {
+                    Image.Version = 24.3;
+                    CodeRegistration = image.ReadMappedObject<Il2CppCodeRegistration>(codeRegistration);
+                }
+
                 // Array of pointers to Il2CppCodeGenModule
                 var codeGenModulePointers = image.ReadMappedArray<ulong>(CodeRegistration.pcodeGenModules, (int) CodeRegistration.codeGenModulesCount);
                 var modules = image.ReadMappedObjectPointerArray<Il2CppCodeGenModule>(CodeRegistration.pcodeGenModules, (int) CodeRegistration.codeGenModulesCount);
@@ -233,8 +240,8 @@ namespace Il2CppInspector
 
             // TODO: Function pointers as shown below
             // reversePInvokeWrappers
-            // <=22: delegateWrappersFromManagedToNative, marshalingFunctions;
-            // >=21 <=22: ccwMarhsalingFunctions
+            // <=22: delegateWrappersFromManagedToNative, marshalingFunctions
+            // >=21 <=22: ccwMarshalingFunctions
             // >=22: unresolvedVirtualCallPointers
             // >=23: interopData
 

--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
@@ -207,8 +207,7 @@ namespace Il2CppInspector
 
             // Some variants of 21 also use an array of pointers
             if (image.Version == 21) {
-                // Always 4-byte values even for 64-bit builds when array is NOT pointers
-                var fieldTest = image.ReadMappedArray<uint>(MetadataRegistration.pfieldOffsets, 6);
+                var fieldTest = image.ReadMappedWordArray(MetadataRegistration.pfieldOffsets, 6);
 
                 // We detect this by relying on the fact Module, Object, ValueType, Attribute, _Attribute and Int32
                 // are always the first six defined types, and that all but Int32 have no fields

--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
@@ -60,6 +60,11 @@ namespace Il2CppInspector
         [Version(Min = 23)]
         public ulong interopData;
 
+        [Version(Min = 24.3)]
+        public ulong windowsRuntimeFactoryCount;
+        [Version(Min = 24.3)]
+        public ulong windowsRuntimeFactoryTable;
+
         // Added in metadata v24.2 to replace methodPointers and methodPointersCount
         [Version(Min = 24.2)]
         public ulong codeGenModulesCount;

--- a/Il2CppInspector.Common/IL2CPP/MetadataClasses.cs
+++ b/Il2CppInspector.Common/IL2CPP/MetadataClasses.cs
@@ -19,12 +19,14 @@ namespace Il2CppInspector
     // Unity 5.3.5f1 -> v21
     // Unity 5.4.0f3 -> v21
     // Unity 5.5.0f3 -> v22
-    // Unity 5.6.2p3 -> v23
+    // Unity 5.6.0f3 -> v23
     // Unity 5.6.4f1 -> v23
-    // Unity 2017.2f3 -> v24
+    // Unity 2019.1.0f3 -> v24
     // Unity 2018.2.0f2 -> v24
     // Unity 2018.3.0f2 -> v24.1
+    // Unity 2019.1.0f2 -> v24.2
     // Unity 2019.2.8f1 -> v24.2
+    // Unity 2019.3.7f1 -> v24.3
     // https://unity3d.com/get-unity/download/archive
     // Metadata version is written at the end of Unity.IL2CPP.MetadataCacheWriter.WriteLibIl2CppMetadata or WriteMetadata (Unity.IL2CPP.dll)
 

--- a/Il2CppInspector.Common/IL2CPP/MetadataClasses.cs
+++ b/Il2CppInspector.Common/IL2CPP/MetadataClasses.cs
@@ -109,9 +109,9 @@ namespace Il2CppInspector
         public int fieldRefsOffset; // Il2CppFieldRef
         [Version(Min = 19)]
         public int fieldRefsCount;
-        [Version(Min = 19)]
+        [Version(Min = 20)]
         public int referencedAssembliesOffset; // int
-        [Version(Min = 19)]
+        [Version(Min = 20)]
         public int referencedAssembliesCount;
 
         [Version(Min = 21)]

--- a/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
+++ b/Il2CppInspector.Common/Outputs/IDAPythonScript.cs
@@ -107,6 +107,11 @@ def MakeFunction(start, end):
         }
 
         private void writeUsages() {
+            if (model.Package.MetadataUsages == null) {
+                /* Version < 19 - no MetadataUsages table */
+                return;
+            }
+
             foreach (var usage in model.Package.MetadataUsages) {
                 var address = usage.VirtualAddress;
                 var name = model.GetMetadataUsageName(usage);
@@ -119,8 +124,7 @@ def MakeFunction(start, end):
                 if (usage.Type == MetadataUsageType.MethodDef || usage.Type == MetadataUsageType.MethodRef) {
                     var method = model.GetMetadataUsageMethod(usage);
                     writeComment(address, method);
-                }
-                else if (usage.Type != MetadataUsageType.StringLiteral) {
+                } else if (usage.Type != MetadataUsageType.StringLiteral) {
                     var type = model.GetMetadataUsageType(usage);
                     writeComment(address, type);
                 }

--- a/README.md
+++ b/README.md
@@ -168,15 +168,16 @@ Unity version | IL2CPP version | Support
 4.6.1+ | First release | Unsupported
 5.2.x | 15 | Unsupported
 5.3.0-5.3.1 | 16 | Working
-5.3.2 | 19 | Untested
-5.3.3-5.3.4 | 20 | Untested
+5.3.2 | 19 | Working
+5.3.3-5.3.4 | 20 | Working
 5.3.5-5.4.x | 21 | Working
 5.5.x | 22 | Working
 5.6.x | 23 | Working
-2017.x-2018.2 | 24.0 | Working
-2018.3-2019.1 | 24.1 | Working
-2019.2-2019.3 | 24.2 | Working
-2020.1 | 24.3 | Awaiting stable release
+2017.1.x-2018.2.x | 24.0 | Working
+2018.3.x-2018.4.x | 24.1 | Working
+2019.1.x-2019.3.6 | 24.2 | Working
+2019.3.7-2019.3.x | 24.3 | Untested
+2020.1 | 24.? | Awaiting stable release
 
 ### Problems
 


### PR DESCRIPTION
I built binaries using all 197 versions of Il2Cpp from 5.3.0f4 to 2019.3.8 using MSVC x86 and x64, and in the process discovered a few compatibility issues with the current Il2CppInspector. This patch series resolves all discovered incompatibilities.

Probably the most contentious patch here is the fix for what I'm calling 24.3 - 2019.3.7+ (released just a few weeks ago - so it's very new). This patch changes `CodeRegistration` in an incompatible way without changing anything about the metadata, which makes versioning a bit trickier. The patch as it is now results in the `Metadata.Version` diverging from `Image.Version`, which is not ideal - ideas to fix this cleanly are welcome.
