### PR TITLE
 Add support for parsing and interpreting VTables

### DIFF
--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinary.cs
@@ -53,6 +53,9 @@ namespace Il2CppInspector
         // One invoker specifies a return type and argument list. Multiple methods with the same signature can be invoked with the same invoker
         public ulong[] MethodInvokePointers { get; private set; }
 
+        // Version 16 and below: method references for vtable
+        public uint[] VTableMethodReferences { get; private set; }
+
         // Generic method specs for vtables
         public Il2CppMethodSpec[] MethodSpecs { get; private set; }
 
@@ -244,6 +247,10 @@ namespace Il2CppInspector
             // >=21 <=22: ccwMarshalingFunctions
             // >=22: unresolvedVirtualCallPointers
             // >=23: interopData
+
+            if (Image.Version < 19) {
+                VTableMethodReferences = image.ReadMappedArray<uint>(MetadataRegistration.methodReferences, (int)MetadataRegistration.methodReferencesCount);
+            }
 
             // Generic type and method specs (open and closed constructed types)
             MethodSpecs = image.ReadMappedArray<Il2CppMethodSpec>(MetadataRegistration.methodSpecs, (int) MetadataRegistration.methodSpecsCount);

--- a/Il2CppInspector.Common/IL2CPP/MetadataUsage.cs
+++ b/Il2CppInspector.Common/IL2CPP/MetadataUsage.cs
@@ -21,13 +21,28 @@ namespace Il2CppInspector
     {
         public MetadataUsageType Type { get; }
         public int SourceIndex { get; }
-        public int DestinationIndex { get; }
         public ulong VirtualAddress { get; private set; }
 
-        public MetadataUsage(MetadataUsageType type, int sourceIndex, int destinationIndex) {
+        public MetadataUsage(MetadataUsageType type, int sourceIndex) {
             Type = type;
             SourceIndex = sourceIndex;
-            DestinationIndex = destinationIndex;
+        }
+
+        public static MetadataUsage FromEncodedIndex(Il2CppInspector package, uint encodedIndex) {
+            uint index;
+            MetadataUsageType usageType;
+            if (package.Version < 19) {
+                /* These encoded indices appear only in vtables, and are decoded by IsGenericMethodIndex/GetDecodedMethodIndex */
+                var isGeneric = encodedIndex & 0x80000000;
+                index = package.Binary.VTableMethodReferences[encodedIndex & 0x7FFFFFFF];
+                usageType = (isGeneric != 0) ? MetadataUsageType.MethodRef : MetadataUsageType.MethodDef;
+            } else {
+                /* These encoded indices appear in metadata usages, and are decoded by GetEncodedIndexType/GetDecodedMethodIndex */
+                var encodedType = encodedIndex & 0xE0000000;
+                usageType = (MetadataUsageType)(encodedType >> 29);
+                index = encodedIndex & 0x1FFFFFFF;
+            }
+            return new MetadataUsage(usageType, (int)index);
         }
 
         public void SetAddress(ulong virtualAddress) => VirtualAddress = virtualAddress;

--- a/Il2CppInspector.Common/Outputs/CSharpCodeStubs.cs
+++ b/Il2CppInspector.Common/Outputs/CSharpCodeStubs.cs
@@ -450,7 +450,7 @@ namespace Il2CppInspector.Outputs
                 sb.Append($"{prefix}\t{modifiers}event {evt.EventHandlerType.GetScopedCSharpName(scope)} {evt.CSharpSafeName}");
                 
                 if (!MustCompile) {
-                    sb.Append(" {{\n");
+                    sb.Append(" {\n");
                     var m = new Dictionary<string, (ulong, ulong)?>();
                     if (evt.AddMethod != null) m.Add("add", evt.AddMethod.VirtualAddress);
                     if (evt.RemoveMethod != null) m.Add("remove", evt.RemoveMethod.VirtualAddress);

--- a/Il2CppInspector.Common/Reflection/TypeInfo.cs
+++ b/Il2CppInspector.Common/Reflection/TypeInfo.cs
@@ -133,6 +133,18 @@ namespace Il2CppInspector.Reflection {
         // Get a property by its name
         public PropertyInfo GetProperty(string name) => DeclaredProperties.FirstOrDefault(p => p.Name == name);
 
+        public MethodBase[] GetVTable() {
+            var definition = Definition;
+
+            MetadataUsage[] vt = Assembly.Model.Package.GetVTable(definition);
+            MethodBase[] res = new MethodBase[vt.Length];
+            for (int i = 0; i < vt.Length; i++) {
+                if (vt[i] != null)
+                    res[i] = Assembly.Model.GetMetadataUsageMethod(vt[i]);
+            }
+            return res;
+        }
+
         // Method that the type is declared in if this is a type parameter of a generic method
         // TODO: Make a unit test from this: https://docs.microsoft.com/en-us/dotnet/api/system.type.declaringmethod?view=netframework-4.8
         public MethodBase DeclaringMethod;


### PR DESCRIPTION
Add support for parsing and interpreting VTables. This is a relatively small patch which just adds support for vtables to the Inspector. This will later be used by the IDA script generator (bigger PR forthcoming).