### PR TITLE
Fix project generation on OS X

### DIFF
--- a/Il2CppInspector.CLI/Program.cs
+++ b/Il2CppInspector.CLI/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using CommandLine;
 using Il2CppInspector.Cpp;
 using Il2CppInspector.Reflection;
@@ -114,7 +115,7 @@ namespace Il2CppInspector.CLI
             Console.WriteLine("Version " + asmInfo.ProductVersion);
             Console.WriteLine(asmInfo.LegalCopyright);
             Console.WriteLine("");
-
+            
             // Check excluded namespaces
             if (options.ExcludedNamespaces.Count() == 1 && options.ExcludedNamespaces.First().ToLower() == "none")
                 options.ExcludedNamespaces = new List<string>();
@@ -131,16 +132,26 @@ namespace Il2CppInspector.CLI
                     Console.Error.WriteLine($"Unity path {unityPath} does not exist");
                     return 1;
                 }
-                
-                if (!File.Exists(unityPath + @"/Contents/Managed/UnityEditor.dll")) {
+
+                string editorPathSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? @"/Contents/Managed/UnityEditor.dll"
+                    : @"\Editor\Data\Managed\UnityEditor.dll";
+
+                if (!File.Exists(unityPath + editorPathSuffix)) {
                     Console.Error.WriteLine($"No Unity installation found at {unityPath}");
                     return 1;
                 }
+                
                 if (!Directory.Exists(unityAssembliesPath)) {
                     Console.Error.WriteLine($"Unity assemblies path {unityAssembliesPath} does not exist");
                     return 1;
                 }
-                if (!File.Exists(unityAssembliesPath + @"/ScriptAssemblies/UnityEngine.UI.dll")) {
+                
+                string uiDllPath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? @"/ScriptAssemblies/UnityEngine.UI.dll"
+                    : @"\UnityEngine.UI.dll";
+                
+                if (!File.Exists(unityAssembliesPath + uiDllPath)) {
                     Console.Error.WriteLine($"No Unity assemblies found at {unityAssembliesPath}");
                     return 1;
                 }

--- a/Il2CppInspector.CLI/Program.cs
+++ b/Il2CppInspector.CLI/Program.cs
@@ -131,7 +131,8 @@ namespace Il2CppInspector.CLI
                     Console.Error.WriteLine($"Unity path {unityPath} does not exist");
                     return 1;
                 }
-                if (!File.Exists(unityPath + @"\Editor\Data\Managed\UnityEditor.dll")) {
+                
+                if (!File.Exists(unityPath + @"/Contents/Managed/UnityEditor.dll")) {
                     Console.Error.WriteLine($"No Unity installation found at {unityPath}");
                     return 1;
                 }
@@ -139,7 +140,7 @@ namespace Il2CppInspector.CLI
                     Console.Error.WriteLine($"Unity assemblies path {unityAssembliesPath} does not exist");
                     return 1;
                 }
-                if (!File.Exists(unityAssembliesPath + @"\UnityEngine.UI.dll")) {
+                if (!File.Exists(unityAssembliesPath + @"/ScriptAssemblies/UnityEngine.UI.dll")) {
                     Console.Error.WriteLine($"No Unity assemblies found at {unityAssembliesPath}");
                     return 1;
                 }

--- a/Il2CppInspector.CLI/Program.cs
+++ b/Il2CppInspector.CLI/Program.cs
@@ -146,13 +146,10 @@ namespace Il2CppInspector.CLI
                     Console.Error.WriteLine($"Unity assemblies path {unityAssembliesPath} does not exist");
                     return 1;
                 }
-                
-                string uiDllPath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                    ? @"/ScriptAssemblies/UnityEngine.UI.dll"
-                    : @"\UnityEngine.UI.dll";
-                
-                if (!File.Exists(unityAssembliesPath + uiDllPath)) {
-                    Console.Error.WriteLine($"No Unity assemblies found at {unityAssembliesPath}");
+
+                string uiDllPath = Path.Combine(unityAssembliesPath, "UnityEngine.UI.dll");
+                if (!File.Exists(uiDllPath)) {
+                    Console.Error.WriteLine($"No UnityEngine.UI.dll assemblies found at {uiDllPath}");
                     return 1;
                 }
 


### PR DESCRIPTION
Unity folder structure is slightly different on OS X. Currently, it's impossible to generate the project file on os x since relative paths to dll are bad. This PR adds platform-dependent path resolution. 