### PR TITLE
polish IDA function creation

### DIFF
--- a/Il2CppInspector.Common/Outputs/ScriptResources/Targets/Ghidra.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/Targets/Ghidra.py
@@ -8,7 +8,7 @@ from ghidra.program.model.symbol import SourceType
 def SetName(addr, name):
 	createLabel(toAddr(addr), name, True)
 
-def MakeFunction(start, name=None):
+def MakeFunction(start, name=None, addrMax=None):
 	addr = toAddr(start)
 	# Don't override existing functions
 	fn = getFunctionAt(addr)

--- a/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
@@ -7,8 +7,16 @@ def SetName(addr, name):
 		new_name = name + '_' + str(addr)
 		ret = idc.set_name(addr, new_name, SN_NOWARN | SN_NOCHECK)
 
-def MakeFunction(start):
-  ida_funcs.add_func(start)
+def MakeFunction(start, name=None, addrMax=None):
+	ida_funcs.add_func(start)
+	#limit end function to maxAddr if any
+	if addrMax is None:
+		return
+	addrEnd = idc.get_func_attr(start,FUNCATTR_END)
+	if addrEnd == idaapi.BADADDR:
+		return
+	if addrEnd > addrMax:
+		idc.set_func_end(start,addrMax)
 
 def MakeArray(addr, numItems, cppType):
 	SetType(addr, cppType)

--- a/Il2CppInspector.Common/Outputs/ScriptResources/shared-main.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/shared-main.py
@@ -96,9 +96,16 @@ def ProcessJSON(jsonData):
 		DefineILMethodInfo(d)
 
 	# Function boundaries
-	print('Processing function boundaries')
-	for d in jsonData['functionAddresses']:
-		MakeFunction(int(d, 0))
+	functionAddresses = jsonData['functionAddresses']
+	count = len(functionAddresses)
+	for i in range(count):
+		addrStart = int(functionAddresses[i],0)
+		if addrStart == 0:
+			continue
+		addrNext = None
+		if i != count -1:
+			addrNext = int(functionAddresses[i+1],0)
+		MakeFunction(addrStart,None,addrNext)
 
 	# IL2CPP type metadata
 	print('Processing IL2CPP type metadata')

--- a/Il2CppInspector.Common/Outputs/ScriptResources/shared-main.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/shared-main.py
@@ -96,7 +96,9 @@ def ProcessJSON(jsonData):
 		DefineILMethodInfo(d)
 
 	# Function boundaries
+	print('Processing function boundaries')
 	functionAddresses = jsonData['functionAddresses']
+	functionAddresses.sort()
 	count = len(functionAddresses)
 	for i in range(count):
 		addrStart = int(functionAddresses[i],0)


### PR DESCRIPTION
when import symbol to IDA,many jump function IDA can't detect the corrent end address automatically.for eaxmple:
bunch of ToString function would output like:
```
void sub_9665E8()
{
  ...
  JUMPOUT(0x96D3D0);
}
```
this is because IDA detect function's end address would be wrong in some cases.especially on ARM set.like:
```
il2cpp:000000000096D3C0                 LDP             X20, X19, [SP,#0x20+var_10]
il2cpp:000000000096D3C4                 LDP             X22, X21, [SP+0x20+var_20],#0x30
il2cpp:000000000096D3C8                 RET
il2cpp:000000000096D3CC ; ---------------------------------------------------------------------------
il2cpp:000000000096D3CC
il2cpp:000000000096D3CC loc_96D3CC                              ; CODE XREF: Number_FormatDouble+2C8↑j
il2cpp:000000000096D3CC                 BL              il2cpp_exception_raise_System_NullReferenceException_f2
il2cpp:000000000096D3CC ; } // starts at 96D31C
il2cpp:000000000096D3D0 ; ---------------------------------------------------------------------------
il2cpp:000000000096D3D0
il2cpp:000000000096D3D0 ; String *__fastcall NumberFormatter_NumberToString_3(String *format, int64_t value, IFormatProvider *fp, MethodInfo *method)
il2cpp:000000000096D3D0 NumberFormatter_NumberToString_3
il2cpp:000000000096D3D0                                         ; CODE XREF: sub_9665E8+A8↑j
il2cpp:000000000096D3D0                                         ; DATA XREF: .data:000000000121EF80↓o
il2cpp:000000000096D3D0 ; __unwind {                            ; String NumberToString(String, Int64, IFormatProvider)
il2cpp:000000000096D3D0                 STP             X22, X21, [SP,#-0x10+var_20]!
il2cpp:000000000096D3D4                 STP             X20, X19, [SP,#0x20+var_10] ; int
il2cpp:000000000096D3D8                 STP             X29, X30, [SP,#0x20+var_s0] ; char
il2cpp:000000000096D3DC                 ADD             X29, SP, #0x20 ; ' '
```
`BL              il2cpp_exception_raise_System_NullReferenceException` is a tail chunk for previous function.but this would cause IDA overlap function start at 0x96D3D0.when this happen. Hex-Rays decompiler wouldn't generate correct code for that.
so this can be fixed by limit function's end address when we create function symbol since the next function's start address we  know.if overlapped we change it other wise touch nothing.
in this patch I change the `MakeFunction`'s signature both in IDA.py and Ghidra.py for keep the signature same.but do nothing in Ghidra.py. I know nothing about Ghidra.
