### PR TITLE
Keep RAW method parameters' name

### DIFF
--- a/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
@@ -23,7 +23,7 @@ def SetFunctionType(addr, sig):
 def SetType(addr, cppType):
   if not cppType.endswith(';'):
     cppType += ';'
-  tinfo = idc.parse_decl(cppType,PT_RAWARGS)
+  tinfo = idc.parse_decl(cppType,idaapi.PT_RAWARGS)
   if not(tinfo is None):
     ret = idc.apply_type(addr,tinfo)
   if ret is None:

--- a/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/Targets/IDA.py
@@ -21,7 +21,13 @@ def SetFunctionType(addr, sig):
   SetType(addr, sig)
 
 def SetType(addr, cppType):
-  ret = idc.SetType(addr, cppType)
+  if not cppType.endswith(';'):
+    cppType += ';'
+  tinfo = idc.parse_decl(cppType,PT_RAWARGS)
+  if not(tinfo is None):
+    ret = idc.apply_type(addr,tinfo)
+  if ret is None:
+    ret = idc.SetType(addr, cppType)
   if ret is None:
     print('SetType(0x%x, %r) failed!' % (addr, cppType))
 


### PR DESCRIPTION
if direct use idc.SetType will remove underscores.this is not we want since the parameters' name are percise.
this made:
```
void __fastcall BluePVPSoldier_DeadByBomber_d_54__ctor(BluePVPSoldier_DeadByBomber_d_54 *this, int32_t 1__state, MethodInfo *method)
{
  Object__ctor(this, 0LL);
  this->__1__state = 1__state;
}
```
to:
```
void __fastcall BluePVPSoldier_DeadByBomber_d_54__ctor(BluePVPSoldier_DeadByBomber_d_54 *this, int32_t __1__state, MethodInfo *method)
{
  Object__ctor(this, 0LL);
  this->__1__state = __1__state;
}
```