### PR TITLE
Add MethodInfo to C++ scaffolding output

### DIFF
--- a/Il2CppInspector.Common/Outputs/CppScaffolding.cs
+++ b/Il2CppInspector.Common/Outputs/CppScaffolding.cs
@@ -173,19 +173,18 @@ typedef size_t uintptr_t;
             writeCode("using namespace app;");
             writeLine("");
 
-            foreach (var method in model.Methods.Values.Where(m => m.HasCompiledCode || m.HasMethodInfo)) {
-                if (method.HasCompiledCode)
-                {
-                    var arguments = string.Join(", ",
-                        method.CppFnPtrType.Arguments.Select(a =>
-                            a.Type.Name + " " + (a.Name == "this" ? "__this" : a.Name)));
+            foreach (var method in model.Methods.Values) {
+                if (method.HasCompiledCode) {
+                    var arguments = string.Join(", ", method.CppFnPtrType.Arguments.Select(a => a.Type.Name + " " + (a.Name == "this" ? "__this" : a.Name)));
+
                     writeCode(
                         $"DO_APP_FUNC(0x{method.MethodCodeAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.ReturnType.Name}, "
                         + $"{method.CppFnPtrType.Name}, ({arguments}));");
                 }
 
-                if (method.HasMethodInfo)
+                if (method.HasMethodInfo) {
                     writeCode($"DO_APP_FUNC_METHODINFO(0x{method.MethodInfoPtrAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.Name}__MethodInfo);");
+                }
             }
 
             writer.Close();

--- a/Il2CppInspector.Common/Outputs/CppScaffolding.cs
+++ b/Il2CppInspector.Common/Outputs/CppScaffolding.cs
@@ -177,9 +177,8 @@ typedef size_t uintptr_t;
                 if (method.HasCompiledCode) {
                     var arguments = string.Join(", ", method.CppFnPtrType.Arguments.Select(a => a.Type.Name + " " + (a.Name == "this" ? "__this" : a.Name)));
 
-                    writeCode(
-                        $"DO_APP_FUNC(0x{method.MethodCodeAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.ReturnType.Name}, "
-                        + $"{method.CppFnPtrType.Name}, ({arguments}));");
+                    writeCode($"DO_APP_FUNC(0x{method.MethodCodeAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.ReturnType.Name}, "
+                              + $"{method.CppFnPtrType.Name}, ({arguments}));");
                 }
 
                 if (method.HasMethodInfo) {

--- a/Il2CppInspector.Common/Outputs/CppScaffolding.cs
+++ b/Il2CppInspector.Common/Outputs/CppScaffolding.cs
@@ -173,10 +173,19 @@ typedef size_t uintptr_t;
             writeCode("using namespace app;");
             writeLine("");
 
-            foreach (var method in model.Methods.Values.Where(m => m.HasCompiledCode)) {
-                var arguments = string.Join(", ", method.CppFnPtrType.Arguments.Select(a => a.Type.Name + " " + (a.Name == "this" ? "__this" : a.Name)));
-                writeCode($"DO_APP_FUNC(0x{method.MethodCodeAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.ReturnType.Name}, "
-                          + $"{method.CppFnPtrType.Name}, ({arguments}));");
+            foreach (var method in model.Methods.Values.Where(m => m.HasCompiledCode || m.HasMethodInfo)) {
+                if (method.HasCompiledCode)
+                {
+                    var arguments = string.Join(", ",
+                        method.CppFnPtrType.Arguments.Select(a =>
+                            a.Type.Name + " " + (a.Name == "this" ? "__this" : a.Name)));
+                    writeCode(
+                        $"DO_APP_FUNC(0x{method.MethodCodeAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.ReturnType.Name}, "
+                        + $"{method.CppFnPtrType.Name}, ({arguments}));");
+                }
+
+                if (method.HasMethodInfo)
+                    writeCode($"DO_APP_FUNC_METHODINFO(0x{method.MethodInfoPtrAddress - model.Package.BinaryImage.ImageBase:X8}, {method.CppFnPtrType.Name}__MethodInfo);");
             }
 
             writer.Close();

--- a/Il2CppInspector.Common/Properties/Resources.resx
+++ b/Il2CppInspector.Common/Properties/Resources.resx
@@ -1187,12 +1187,12 @@ EndGlobal
 
 // Application-specific functions
 #define DO_APP_FUNC(a, r, n, p) extern r (*n) p
-#define DO_APP_FUNC_INFO(a, n) extern struct MethodInfo * n
+#define DO_APP_FUNC_METHODINFO(a, n) extern struct MethodInfo * n
 namespace app {
 	#include "il2cpp-functions.h"
 }
 #undef DO_APP_FUNC
-#undef DO_APP_FUNC_INFO
+#undef DO_APP_FUNC_METHODINFO
 
 // TypeInfo pointers
 #define DO_TYPEDEF(a, n) extern n ## __Class** n ## __TypeInfo

--- a/Il2CppInspector.Common/Properties/Resources.resx
+++ b/Il2CppInspector.Common/Properties/Resources.resx
@@ -1187,10 +1187,12 @@ EndGlobal
 
 // Application-specific functions
 #define DO_APP_FUNC(a, r, n, p) extern r (*n) p
+#define DO_APP_FUNC_INFO(a, n) extern struct MethodInfo * n
 namespace app {
 	#include "il2cpp-functions.h"
 }
 #undef DO_APP_FUNC
+#undef DO_APP_FUNC_INFO
 
 // TypeInfo pointers
 #define DO_TYPEDEF(a, n) extern n ## __Class** n ## __TypeInfo
@@ -1216,10 +1218,12 @@ namespace app {
 
 // Application-specific functions
 #define DO_APP_FUNC(a, r, n, p) r (*n) p
+#define DO_APP_FUNC_METHODINFO(a, n) struct MethodInfo * n
 namespace app {
 #include "il2cpp-functions.h"
 }
 #undef DO_APP_FUNC
+#undef DO_APP_FUNC_METHODINFO
 
 // TypeInfo pointers
 #define DO_TYPEDEF(a, n) n ## __Class** n ## __TypeInfo
@@ -1243,8 +1247,10 @@ void init_il2cpp()
 
 	// Define function addresses
 	#define DO_APP_FUNC(a, r, n, p) n = (r (*) p)(baseAddress + a)
+ 	#define DO_APP_FUNC_METHODINFO(a, n) n = (struct MethodInfo *)(baseAddress + a)
 	#include "il2cpp-functions.h"
 	#undef DO_APP_FUNC
+ 	#undef DO_APP_FUNC_METHODINFO
 
 	// Define TypeInfo variables
 	#define DO_TYPEDEF(a, n) n ## __TypeInfo = (n ## __Class**) (baseAddress + a);


### PR DESCRIPTION
I recently needed to access static properties of a type for which no `TypeInfo` was present, however `MethodInfo` was there and analysis of the game in IDA showed that passing a proper MethodInfo pointer was necessary. Hence this pull request.

Let me know of there's anything to change (code style, naming, moving these pointers to another header file, etc)

Cheers