### PR TITLE
Use getSourceFile to find Ghidra script location

### DIFF
--- a/Il2CppInspector.Common/Outputs/ScriptResources/Targets/Ghidra.py
+++ b/Il2CppInspector.Common/Outputs/ScriptResources/Targets/Ghidra.py
@@ -71,5 +71,4 @@ def CustomInitializer():
 		currentProgram.setImageBase(toAddr(0), True)
 
 def GetScriptDirectory():
-	# Ghidra doesn't define __file__ so we have to iterate all the scripts
-	return next(iter(filter(lambda x: x.getName() == '%SCRIPTFILENAME%', GhidraScriptUtil.getAllScripts())), None).getParentFile().toString()
+	return getSourceFile().getParentFile().toString()


### PR DESCRIPTION
`getAllScripts` was removed in a recent commit <https://github.com/NationalSecurityAgency/ghidra/commit/2b49816c6cf45b5d23706c69bed46e49f0acd8c5#diff-67260297e0f38cd74fe3ea2693266e52L555-L565>

Use `getSourceFile` instead