### PR TITLE
Support for reading codereg of metadata 27.1

### DIFF
--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
@@ -37,7 +37,8 @@ namespace Il2CppInspector
 
         public ulong genericMethodPointersCount;
         public ulong genericMethodPointers;
-        [Version(Min = 27.1)] public ulong genericAdjustorThunks;
+        [Version(Min = 27.1)] 
+        public ulong genericAdjustorThunks;
         public ulong invokerPointersCount;
         public ulong invokerPointers;
 
@@ -83,8 +84,10 @@ namespace Il2CppInspector
         public ulong moduleName;
         public ulong methodPointerCount;
         public ulong methodPointers;
-        [Version(Min = 27.1)] public long adjustorThunkCount;
-        [Version(Min = 27.1)] public ulong adjustorThunks; //Pointer
+        [Version(Min = 27.1)] 
+        public long adjustorThunkCount;
+        [Version(Min = 27.1)]
+        public ulong adjustorThunks; //Pointer
         public ulong invokerIndices;
         public ulong reversePInvokeWrapperCount;
         public ulong reversePInvokeWrapperIndices;
@@ -253,6 +256,7 @@ namespace Il2CppInspector
     {
         public int methodIndex;
         public int invokerIndex;
-        [Version(Min = 27.1)] public int adjustorThunk;
+        [Version(Min = 27.1)] 
+        public int adjustorThunk;
     }
 }

--- a/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
+++ b/Il2CppInspector.Common/IL2CPP/Il2CppBinaryClasses.cs
@@ -37,6 +37,7 @@ namespace Il2CppInspector
 
         public ulong genericMethodPointersCount;
         public ulong genericMethodPointers;
+        [Version(Min = 27.1)] public ulong genericAdjustorThunks;
         public ulong invokerPointersCount;
         public ulong invokerPointers;
 
@@ -82,6 +83,8 @@ namespace Il2CppInspector
         public ulong moduleName;
         public ulong methodPointerCount;
         public ulong methodPointers;
+        [Version(Min = 27.1)] public long adjustorThunkCount;
+        [Version(Min = 27.1)] public ulong adjustorThunks; //Pointer
         public ulong invokerIndices;
         public ulong reversePInvokeWrapperCount;
         public ulong reversePInvokeWrapperIndices;
@@ -250,5 +253,6 @@ namespace Il2CppInspector
     {
         public int methodIndex;
         public int invokerIndex;
+        [Version(Min = 27.1)] public int adjustorThunk;
     }
 }

--- a/Il2CppInspector.Common/IL2CPP/ImageScan.cs
+++ b/Il2CppInspector.Common/IL2CPP/ImageScan.cs
@@ -141,8 +141,8 @@ namespace Il2CppInspector
 
                 if (Image.Version == 27 && cr.reversePInvokeWrapperCount > 0x30000)
                 {
-                    //If reversePInvokeWrapperCount is a pointer, then it's because we're actually on 27.1 and there's a genericAdjustorThunks pointer interfering.
-                    //We need to bump version to 27.1 and back up one more pointer.
+                    // If reversePInvokeWrapperCount is a pointer, then it's because we're actually on 27.1 and there's a genericAdjustorThunks pointer interfering.
+                    // We need to bump version to 27.1 and back up one more pointer.
                     Image.Version = 27.1;
                     codeRegistration -= ptrSize;
                 }

--- a/Il2CppInspector.Common/IL2CPP/ImageScan.cs
+++ b/Il2CppInspector.Common/IL2CPP/ImageScan.cs
@@ -138,6 +138,14 @@ namespace Il2CppInspector
                     Image.Version = 24.3;
                     codeRegistration -= ptrSize * 2; // two extra words for WindowsRuntimeFactory
                 }
+
+                if (Image.Version == 27 && cr.reversePInvokeWrapperCount > 0x30000)
+                {
+                    //If reversePInvokeWrapperCount is a pointer, then it's because we're actually on 27.1 and there's a genericAdjustorThunks pointer interfering.
+                    //We need to bump version to 27.1 and back up one more pointer.
+                    Image.Version = 27.1;
+                    codeRegistration -= ptrSize;
+                }
             }
 
             // Find CodeRegistration


### PR DESCRIPTION
Adds support for the "Adjustor Thunks" used in metadata version 27.1 (Unity 2020.2.4), sets the image version to 27.1 if they're detected, and adjusts the location of the detected codereg struct accordingly.

Does not include updated Unity headers, so the app crashes with a fatal error once the binary read completes, due to them being missing.