### PR TITLE
add declared type namespace to json

### DIFF
--- a/Il2CppInspector.Common/Outputs/JSONMetadata.cs
+++ b/Il2CppInspector.Common/Outputs/JSONMetadata.cs
@@ -73,6 +73,7 @@ namespace Il2CppInspector.Outputs
                 writeObject(() => {
                     writeTypedFunctionName(method.MethodCodeAddress, method.CppFnPtrType.ToSignatureString(), method.CppFnPtrType.Name);
                     writeDotNetSignature(method.Method);
+                    writeDeclaredTypeNamespace(method.Method);
                 });
             }
         }
@@ -259,6 +260,10 @@ namespace Il2CppInspector.Outputs
 
         private void writeDotNetSignature(MethodBase method) {
             writer.WriteString("dotNetSignature", method.ToString().ToEscapedString());
+        }
+
+        private void writeDeclaredTypeNamespace(MethodBase method) {
+            writer.WriteString("declared_type_namespace", method.DeclaringType.Namespace);
         }
 
         private void writeDotNetTypeName(TypeInfo type) {


### PR DESCRIPTION
👋 Thanks for this tool! I've been writing some tooling to automatically dump things from GHIDRA, and currentlyt he dump takes ~4 hours because it's just dumping everything in the `metadata.json`. I was looking to filter out dumping any `Mono`/`System` methods, in order to do that because there may be conflicting names without namespaces I figured I'd just add the namespace to the JSON, and filter on that.