### PR TITLE
C++: Fix Il2CppDecimal declaration and add missing reserved symbols

### DIFF
--- a/Il2CppInspector.Common/Cpp/CppDeclarationGenerator.cs
+++ b/Il2CppInspector.Common/Cpp/CppDeclarationGenerator.cs
@@ -542,7 +542,7 @@ namespace Il2CppInspector.Cpp
             }
             /* Reserve commonly defined C++ symbols for MSVC DLL projects */
             /* This is not an exhaustive list! (windows.h etc.) */
-            foreach (var symbol in new[] {"_int32", "DEFAULT_CHARSET", "FILETIME", "NULL", "SYSTEMTIME", "stderr", "stdin", "stdout"}) {
+            foreach (var symbol in new[] { "_int8", "_int16", "_int32", "_int64", "DEFAULT_CHARSET", "FILETIME", "NULL", "SYSTEMTIME", "stderr", "stdin", "stdout"}) {
                 ns.ReserveName(symbol);
             }
             /* Reserve builtin keywords in IDA */

--- a/Il2CppInspector.Common/Cpp/UnityHeaders/24-2017.4.15-2017.4.40.h
+++ b/Il2CppInspector.Common/Cpp/UnityHeaders/24-2017.4.15-2017.4.40.h
@@ -1868,7 +1868,7 @@ struct Il2CppDecimal
         } v;
         uint64_t Lo64;
     } v;
-} Il2CppClass;
+};
 typedef struct Il2CppDouble
 {
     uint32_t mantLo : 32;


### PR DESCRIPTION
Few quick fixes for correct cpp scaffolding generation