### PR TITLE
Add namespaces to the types' names.

### DIFF
--- a/Il2CppInspector.Common/Cpp/CppDeclarationGenerator.cs
+++ b/Il2CppInspector.Common/Cpp/CppDeclarationGenerator.cs
@@ -520,7 +520,8 @@ namespace Il2CppInspector.Cpp
             TypeNamer = TypeNamespace.MakeNamer<TypeInfo>((ti) => {
                 if (ti.IsArray)
                     return TypeNamer.GetName(ti.ElementType) + "__Array";
-                var name = ti.Name.ToCIdentifier();
+                var name = ti.Namespace + (String.IsNullOrEmpty(ti.Namespace) ? "" : ".") + ti.Name;
+                name = name.ToCIdentifier();
                 name = Regex.Replace(name, "__+", "_");
                 // Work around a dumb IDA bug: enums can't be named the same as certain "built-in" types
                 // like KeyCode, Position, ErrorType. This only applies to enums, not structs.

--- a/Il2CppInspector.Common/Properties/Resources.resx
+++ b/Il2CppInspector.Common/Properties/Resources.resx
@@ -193,7 +193,7 @@ std::string il2cppi_to_string(Il2CppString* str) {
 }
 
 // Helper function to convert System.String to std::string
-std::string il2cppi_to_string(app::String* str) {
+std::string il2cppi_to_string(app::System_String* str) {
     return il2cppi_to_string(reinterpret_cast&lt;Il2CppString*&gt;(str));
 }
 #endif</value>
@@ -224,7 +224,7 @@ void il2cppi_new_console();
 std::string il2cppi_to_string(Il2CppString* str);
 
 // Helper function to convert System.String to std::string
-std::string il2cppi_to_string(app::String* str);
+std::string il2cppi_to_string(app::System_String* str);
 #endif
 
 // Helper function to check if a metadata usage pointer is initialized


### PR DESCRIPTION
I changed the type names from only their names to "namespace.type_name".
This is to minimize the chances of two types with the same name. Adding _1 to the type name is ugly.